### PR TITLE
docs: fix label textarea

### DIFF
--- a/docs/src/components/form.njk
+++ b/docs/src/components/form.njk
@@ -28,7 +28,7 @@ toc:
   </div>
 
   <div class="grid gap-2">
-    <label for="demo-form-text">Bio</label>
+    <label for="demo-form-textarea">Bio</label>
     <textarea id="demo-form-textarea" placeholder="I like to..." rows="3"></textarea>
     <p class="text-muted-foreground text-sm">You can @mention other users and organizations.</p>
   </div>


### PR DESCRIPTION
Fixes the `Bio`'s field label inside the `Form` example having the wrong `for` attribute.