### PR TITLE
Add `--input-background` variable

### DIFF
--- a/docs/src/components/button.njk
+++ b/docs/src/components/button.njk
@@ -54,7 +54,6 @@ toc:
         <li><code>btn-outline</code> for outline buttons.</li>
         <li><code>btn-ghost</code> for ghost buttons.</li>
         <li><code>btn-link</code> for link buttons.</li>
-        <li><code>btn-input</code> mimics the appearance of input elements, used primarily for custom <a href="/components/select"><code>Select</code></a> implementation.</li>
         <li><code>btn-icon</code> for icon buttons. This can be combined with other variants, for example <code>btn-icon-destructive</code>.</li>
       </ul>
     </li>

--- a/src/css/basecoat.css
+++ b/src/css/basecoat.css
@@ -193,7 +193,6 @@
   .btn-ghost,
   .btn-link,
   .btn-destructive,
-  .btn-input,
   .btn-sm,
   .btn-sm-primary,
   .btn-sm-secondary,
@@ -201,7 +200,6 @@
   .btn-sm-ghost,
   .btn-sm-link,
   .btn-sm-destructive,
-  .btn-sm-input,
   .btn-lg,
   .btn-lg-primary,
   .btn-lg-secondary,
@@ -209,7 +207,6 @@
   .btn-lg-ghost,
   .btn-lg-link,
   .btn-lg-destructive,
-  .btn-lg-input,
   .btn-icon,
   .btn-icon-primary,
   .btn-icon-secondary,
@@ -217,7 +214,6 @@
   .btn-icon-ghost,
   .btn-icon-link,
   .btn-icon-destructive,
-  .btn-icon-input,
   .btn-sm-icon,
   .btn-sm-icon-primary,
   .btn-sm-icon-secondary,
@@ -225,15 +221,13 @@
   .btn-sm-icon-ghost,
   .btn-sm-icon-link,
   .btn-sm-icon-destructive,
-  .btn-sm-icon-input,
   .btn-lg-icon,
   .btn-lg-icon-primary,
   .btn-lg-icon-secondary,
   .btn-lg-icon-outline,
   .btn-lg-icon-ghost,
   .btn-lg-icon-link,
-  .btn-lg-icon-destructive,
-  .btn-lg-icon-input {
+  .btn-lg-icon-destructive {
     @apply inline-flex items-center justify-center whitespace-nowrap text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-md;
   }
   .btn,
@@ -242,8 +236,7 @@
   .btn-outline,
   .btn-ghost,
   .btn-link,
-  .btn-destructive,
-  .btn-input {
+  .btn-destructive {
     @apply gap-2 h-9 px-4 py-2 has-[>svg]:px-3;
   }
   .btn-icon,
@@ -252,8 +245,7 @@
   .btn-icon-outline,
   .btn-icon-ghost,
   .btn-icon-link,
-  .btn-icon-destructive,
-  .btn-icon-input {
+  .btn-icon-destructive {
     @apply size-9;
   }
   .btn-sm,
@@ -262,8 +254,7 @@
   .btn-sm-outline,
   .btn-sm-ghost,
   .btn-sm-link,
-  .btn-sm-destructive,
-  .btn-sm-input {
+  .btn-sm-destructive {
     @apply gap-1.5 h-8 px-3 has-[>svg]:px-2.5;
   }
   .btn-sm-icon,
@@ -272,8 +263,7 @@
   .btn-sm-icon-outline,
   .btn-sm-icon-ghost,
   .btn-sm-icon-link,
-  .btn-sm-icon-destructive,
-  .btn-sm-icon-input {
+  .btn-sm-icon-destructive {
     @apply size-8;
   }
   .btn-lg,
@@ -282,8 +272,7 @@
   .btn-lg-outline,
   .btn-lg-ghost,
   .btn-lg-link,
-  .btn-lg-destructive,
-  .btn-lg-input {
+  .btn-lg-destructive {
     @apply gap-2 h-10 px-6 has-[>svg]:px-4;
   }
   .btn-lg-icon,
@@ -292,8 +281,7 @@
   .btn-lg-icon-outline,
   .btn-lg-icon-ghost,
   .btn-lg-icon-link,
-  .btn-lg-icon-destructive,
-  .btn-lg-icon-input {
+  .btn-lg-icon-destructive {
     @apply size-10;
   }
   .btn,
@@ -370,18 +358,6 @@
     &:hover,
     &[aria-pressed='true'] {
       @apply bg-destructive/90 dark:bg-destructive/50;
-    }
-  }
-  .btn-input,
-  .btn-sm-input,
-  .btn-lg-input,
-  .btn-icon-input,
-  .btn-sm-icon-input,
-  .btn-lg-icon-input {
-    @apply border shadow-xs bg-input-background;
-    &:hover,
-    &[aria-pressed='true'] {
-      @apply bg-input-background text-foreground dark:bg-input/50;
     }
   }
 }

--- a/src/jinja/select.html.jinja
+++ b/src/jinja/select.html.jinja
@@ -63,7 +63,7 @@
 >
   <button
     type="button"
-    class="btn-input justify-between font-normal {{ trigger_attrs.class }}"
+    class="btn-outline justify-between font-normal {{ trigger_attrs.class }}"
     id="{{ id }}-trigger"
     aria-haspopup="listbox"
     aria-expanded="false"

--- a/src/nunjucks/select.njk
+++ b/src/nunjucks/select.njk
@@ -63,7 +63,7 @@
 >
   <button
     type="button"
-    class="btn-input justify-between font-normal {{ trigger_attrs.class }}"
+    class="btn-outline justify-between font-normal {{ trigger_attrs.class }}"
     id="{{ id }}-trigger"
     aria-haspopup="listbox"
     aria-expanded="false"


### PR DESCRIPTION
Currently Basecoat has hard-coded background for inputs elements in light mode - `transparent`. This is suboptimal for cases, when background is not white, as border alone doesn't provide enough contrast affordance to comfortably distinguish the inputs. It's most noticeable in the "Doom 64" theme on the docs website, "Claude" theme is also affected. It also limits theming options, as changing background of input elements requires altering the source of Basecoat

|Claude |Doom 64 |
|-|-|
|![image](https://github.com/user-attachments/assets/08753a07-2ff3-497f-9d29-3cd36be577ca)|![image](https://github.com/user-attachments/assets/2c87fd7f-7cdd-4c97-ae27-95d45c608198)|

This PR introduces a variable for inputs background color and updates the themes to make use of it

|Claude |Doom 64 |
|-|-|
|![image](https://github.com/user-attachments/assets/b9387c9a-8777-40d2-a526-2479f40051c4)|![image](https://github.com/user-attachments/assets/c09ed590-1c24-4755-a1b8-178cbc3099c2)|

**Note:** I realize that this PR breaks the convention of `--thing` + `--thing-foreground` and introduces `--thing-background` + `--thing` instead. My intention was to preserve backwards compatibility for those, who may have a dependency of `--input` variable being the foreground color. Let me know if I should change to the already used convention

Update:

I also introduce a new style for the buttons - `btn-input`, which is used for custom `select` element, so that it looks consistent with native `<select>` tag. If you think I should figure it out on the component level rather than introducing a whole new button style, let me know, I'll try to figure something out

Update:

I removed the new button style to keep the PR simple. Custom selects situation can be figured out later