### PR TITLE
Blur only occurs when the active element is inside the toast.

### DIFF
--- a/src/js/toast.js
+++ b/src/js/toast.js
@@ -99,7 +99,7 @@
     clearTimeout(state.timeoutId);
     toasts.delete(element);
     
-    if (document.activeElement) document.activeElement.blur();
+    if (element.contains(document.activeElement)) document.activeElement.blur();
     element.setAttribute('aria-hidden', 'true');
     element.addEventListener('transitionend', () => element.remove(), { once: true });
   }


### PR DESCRIPTION
Hi all,

This PR pertains to #85.

When the toast timer elapses and `closeToast` is called `if (document.activeElement) document.activeElement.blur()` will be called. Once it is called, if a user  is say, typing into an input field, they will lose focus.

On the other hand, if the user presses the dismiss button, we have to blur to be able to set the `aria-hidden` to `true`.

Instead of calling `blur()` in all cases, we can check whether the `toast` contains the active element (for example, when a button is pressed) and then calling blur on the active element before setting the `aria-hidden` attribute thereby avoiding the `Blocked aria-hidden on an element because its descendant retained focus` warning.