### PR TITLE
docs: Add anchor tag to /kitchen-sink/#form

### DIFF
--- a/docs/src/_includes/partials/kitchen-sink/form.njk
+++ b/docs/src/_includes/partials/kitchen-sink/form.njk
@@ -1,6 +1,9 @@
 <section id="form" class="w-full rounded-lg border scroll-mt-16">
   <header class="border-b px-4 py-3">
     <h2 class="text-sm font-medium">Form</h2>
+    <a href="/components/form" class="text-muted-foreground hover:text-foreground" data-tooltip="See documentation" data-side="left">
+      {% lucide "book-open", { "class": "size-4" }   %}
+    </a>
   </header>
   <div class="p-4">
     <form class="form grid w-full max-w-sm gap-6">


### PR DESCRIPTION
The Form section of the Kitchen Sink page is missing its link to the Form component page