### PR TITLE
Fix: change tooltip background to bg-foreground

### DIFF
--- a/docs/src/components/popover.njk
+++ b/docs/src/components/popover.njk
@@ -103,8 +103,8 @@ toc:
         <li><code>onclick</code>: a simple function to update <code>aria-expanded</code>.</li>
       </ul>
     </dd>
-    <dt><code class="highlight language-html">&lt;div popover class="popover" id="{ POPOVER_ID }"&gt;</code></dt>
-    <dd>As with the <a href="/components/popover">Popover</a> component, you can set up the side and alignment of the popover using the <code>data-side</code> and <code>data-align</code> attributes.</dd>
+    <dt><code class="highlight language-html">&lt;div data-popover class="popover" id="{ POPOVER_ID }"&gt;</code></dt>
+    <dd>You can set up the side and alignment of the popover using the <code>data-side</code> and <code>data-align</code> attributes.</dd>
   </dl>
 </section>
 

--- a/src/css/basecoat.css
+++ b/src/css/basecoat.css
@@ -1040,7 +1040,7 @@
     @apply relative;
 
     &:before {
-      @apply absolute content-[attr(data-tooltip)] bg-primary text-primary-foreground z-[60] truncate max-w-xs w-fit rounded-md px-3 py-1.5 text-xs invisible opacity-0 scale-95 transition-all pointer-events-none;
+      @apply absolute content-[attr(data-tooltip)] bg-foreground text-primary-foreground z-[60] truncate max-w-xs w-fit rounded-md px-3 py-1.5 text-xs invisible opacity-0 scale-95 transition-all pointer-events-none;
     }
     &:hover:before {
       @apply visible opacity-100 scale-100;


### PR DESCRIPTION
With the primary color in theming often reserved for something more vibrant, `bg-foreground` seems more suited as a default background color for the tooltip element. 

Can currently be overriden as:
```
@layer components {
    [data-tooltip]::before {
        @apply bg-foreground;
    }
}
```