### PR TITLE
fix: change tooltip bg color to bg-foreground

### DIFF
--- a/src/css/basecoat.css
+++ b/src/css/basecoat.css
@@ -1040,7 +1040,7 @@
     @apply relative;
 
     &:before {
-      @apply absolute content-[attr(data-tooltip)] bg-primary text-primary-foreground z-[60] truncate max-w-xs w-fit rounded-md px-3 py-1.5 text-xs invisible opacity-0 scale-95 transition-all pointer-events-none;
+      @apply absolute content-[attr(data-tooltip)] bg-foreground text-primary-foreground z-[60] truncate max-w-xs w-fit rounded-md px-3 py-1.5 text-xs invisible opacity-0 scale-95 transition-all pointer-events-none;
     }
     &:hover:before {
       @apply visible opacity-100 scale-100;


### PR DESCRIPTION
With the primary color in theming often reserved for something more vibrant, `bg-foreground` seems more suited as a default background color for the tooltip element. 

Can currently be overriden as:
```
@layer components {
    [data-tooltip]::before {
        @apply bg-foreground;
    }
}
```