### PR TITLE
Kitchensink fixes

### DIFF
--- a/docs/src/_includes/partials/kitchen-sink/combobox.njk
+++ b/docs/src/_includes/partials/kitchen-sink/combobox.njk
@@ -56,7 +56,7 @@
         }
       ] %}
       {% call select(
-        popover_attrs={"class": "w-72"},
+        popover_attrs={"class": "w-72", "data-align": "end"},
         listbox_attrs={"data-empty": "No timezone found."},
         is_combobox=true
       ) %}

--- a/docs/src/_includes/partials/kitchen-sink/dropdown-menu.njk
+++ b/docs/src/_includes/partials/kitchen-sink/dropdown-menu.njk
@@ -171,7 +171,7 @@
         id="dropdown-menu-radio-group",
         trigger="Radio Group",
         trigger_attrs={"class": "btn-outline"},
-        popover_attrs={"class": "min-w-56"}
+        popover_attrs={"class": "min-w-56", "data-align": "end"}
       ) %}
       <div role="group" aria-labelledby="position-options">
         <span id="position-options" role="heading">Panel Position</span>
@@ -273,7 +273,7 @@
         id="dropdown-checkboxes",
         trigger=trigger,
         trigger_attrs={"class": "btn-icon-ghost"},
-        popover_attrs={"class": "min-w-32"}
+        popover_attrs={"class": "min-w-32", "data-align": "end"}
       ) %}
         <div role="menuitem">
           {% lucide "pencil" %}


### PR DESCRIPTION
When you look at the kitchensink on mobile, the width of the page exceeds 100% (you can scroll horizontally a bit). This can be fixed by setting the popover placement
<img width="238" height="281" alt="Screenshot 2025-11-17 at 09 37 37" src="https://github.com/user-attachments/assets/42baf4fe-c49a-43fd-a70e-9c514af5ebfb" />