### PR TITLE
fixing dropdown background color (white mode) for claude.css

### DIFF
--- a/docs/css/themes/claude.css
+++ b/docs/css/themes/claude.css
@@ -4,7 +4,7 @@
     --foreground: oklch(0.34 0.03 95.72);
     --card: oklch(0.98 0.01 95.10);
     --card-foreground: oklch(0.19 0.00 106.59);
-    --popover: oklch(1.00 0 0);
+    --popover: oklch(0.98 0.01 95.10);
     --popover-foreground: oklch(0.27 0.02 98.94);
     --primary: oklch(0.62 0.14 39.04);
     --primary-foreground: oklch(1.00 0 0);


### PR DESCRIPTION
the dropdown color for claude (white mode) was 100% white, which is really weird (see dropdown component in claude white mode).
<img width="309" height="210" alt="Capture d’écran du 2026-01-20 00-00-17" src="https://github.com/user-attachments/assets/2f9ca9ec-3498-4bd5-bc5c-f7f8a4dc25d5" />
