### PR TITLE
docs: fix inconsistent description in alert no-icon example

### DIFF
--- a/docs/src/components/alert.njk
+++ b/docs/src/components/alert.njk
@@ -103,6 +103,6 @@ toc:
 
 {% set code %}<div class="alert">
   <h2>Success! Your changes have been saved</h2>
-  <section>This is an alert with icon, title and description.</section>
+  <section>This is an alert with title and description only.</section>
 </div>{% endset %}
 {{ code_preview("alert-no-icon", code) }}


### PR DESCRIPTION
The "No icon" example says "with icon, title and description." but has no icon. Changed to "with title and description only."