### PR TITLE
Fix a usability issue with Command - previous text gets in the way of subsequent invocations

### DIFF
--- a/src/js/command.js
+++ b/src/js/command.js
@@ -150,6 +150,21 @@
       visibleMenuItems[0].scrollIntoView({ block: 'nearest' });
     }
 
+    // Select input text when dialog opens. This makes it easier to type a
+    // new command without having to delete the existing command.
+    const dialog = container.closest('dialog.command-dialog');
+    if (dialog) {
+      const dialogObserver = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+          if (mutation.attributeName === 'open' && dialog.hasAttribute('open')) {
+            input.select();
+            break;
+          }
+        }
+      });
+      dialogObserver.observe(dialog, { attributes: true, attributeFilter: ['open'] });
+    }
+
     container.dataset.commandInitialized = true;
     container.dispatchEvent(new CustomEvent('basecoat:initialized'));
   };


### PR DESCRIPTION
Hiya,

This fixes a usability issue I noticed when opening the command dialog. If there's existing text from a previous use, that text gets in the way of entering new text. Users have to delete it first before entering new text. 

The way other such components in the wild work is by selecting existing text so that users can type over if they prefer (or edit the existing text if they prefer). For example the MacOS Spotlight Search does this.

To test:
- Run it locally and visit http://localhost:8080/components/command/#examples
- Click on the command button right at the bottom, or type ⌘J
- Enter some text to select a command (e.g. `oji` to select 'Search Emoji'), and hit ENTER
- Re-open the command the same way
- You should now see your previously entered text selected.
- You should be able to type another command by typing over the selection.
