### PR TITLE
Add initIn for scoped initialization/reinitialization and fix select reinit issues

### DIFF
--- a/docs/src/llms.txt
+++ b/docs/src/llms.txt
@@ -14,7 +14,7 @@ CDN
 
 JavaScript
 - Auto‑init on `DOMContentLoaded`; observes DOM for new nodes.
-- Manual: `window.basecoat.init('<name>')` or `window.basecoat.initAll()`.
+- Manual: `window.basecoat.init('<name>')`, `window.basecoat.initAll()`, or `window.basecoat.initIn(container, options?)`.
 - Packages to import with ESM: `import 'basecoat-css/all'` or `import 'basecoat-css/tabs'`.
 
 Usage
@@ -81,7 +81,7 @@ Accessibility
 
 Troubleshooting
 - If a component doesn’t work, ensure its JS is loaded and required roles/IDs match examples.
-- For dynamic content, call `window.basecoat.init('<name>')` or `initAll()` after insertion.
+- For dynamic content, call `window.basecoat.init('<name>')`, `window.basecoat.initAll()`, or `window.basecoat.initIn(container, options?)` after insertion.
 
 License
 - MIT (see LICENSE.md)
@@ -126,6 +126,7 @@ import 'basecoat-css/toast';
 ```js
 window.basecoat.init('tabs');
 window.basecoat.initAll();
+window.basecoat.initIn(container, { component: 'tabs' });
 ```
 
 ## Basecoat usage rules
@@ -500,7 +501,7 @@ Additional CSS components include: `progress`, `skeleton`, `slider`, `spinner`, 
 
 ## Troubleshooting
 - If interactivity doesn’t work, ensure the component’s JS is included and required roles/IDs match the examples.
-- For dynamic content, call `window.basecoat.init('<name>')` or `window.basecoat.initAll()` after insertion.
+- For dynamic content, call `window.basecoat.init('<name>')`, `window.basecoat.initAll()`, or `window.basecoat.initIn(container, options?)` after insertion.
 
 ## License
 MIT (see LICENSE.md)

--- a/src/js/basecoat.js
+++ b/src/js/basecoat.js
@@ -1,6 +1,26 @@
 (() => {
   const componentRegistry = {};
   let observer = null;
+  const NODE_TYPES = {
+    ELEMENT: 1,
+    DOCUMENT: 9,
+    DOCUMENT_FRAGMENT: 11
+  };
+
+  const getScopedElements = (container, selector) => {
+    const elements = [];
+
+    if (
+      container.nodeType === NODE_TYPES.ELEMENT &&
+      typeof container.matches === 'function' &&
+      container.matches(selector)
+    ) {
+      elements.push(container);
+    }
+
+    elements.push(...container.querySelectorAll(selector));
+    return elements;
+  };
 
   const registerComponent = (name, selector, initFunction) => {
     componentRegistry[name] = {
@@ -84,10 +104,50 @@
     initAllComponents();
   };
 
+  const initInScope = (container, options = {}) => {
+    if (
+      !container ||
+      typeof container !== 'object' ||
+      ![
+        NODE_TYPES.ELEMENT,
+        NODE_TYPES.DOCUMENT,
+        NODE_TYPES.DOCUMENT_FRAGMENT
+      ].includes(container.nodeType)
+    ) {
+      console.warn('Invalid container passed to basecoat.initIn()', container);
+      return;
+    }
+
+    const { component: componentName, force = false } = options;
+    const componentNames = componentName ? [componentName] : Object.keys(componentRegistry);
+
+    if (componentName && !componentRegistry[componentName]) {
+      console.warn(`Component '${componentName}' not found in registry`);
+      return;
+    }
+
+    if (force) {
+      componentNames.forEach((name) => {
+        const flag = `data-${name}-initialized`;
+        getScopedElements(container, `[${flag}]`).forEach((element) => {
+          element.removeAttribute(flag);
+        });
+      });
+    }
+
+    componentNames.forEach((name) => {
+      const component = componentRegistry[name];
+      getScopedElements(container, component.selector).forEach((element) => {
+        initComponent(element, name);
+      });
+    });
+  };
+
   window.basecoat = {
     register: registerComponent,
     init: reinitComponent,
     initAll: reinitAll,
+    initIn: initInScope,
     start: startObserver,
     stop: stopObserver
   };

--- a/src/js/select.js
+++ b/src/js/select.js
@@ -17,6 +17,8 @@
       return;
     }
 
+    selectComponent._basecoatSelectDestroy?.();
+
     const allOptions = Array.from(listbox.querySelectorAll('[role="option"]'));
     const options = allOptions.filter(opt => opt.getAttribute('aria-disabled') !== 'true');
     let visibleOptions = [...options];
@@ -160,8 +162,10 @@
       toggleMultipleValue(option);
     };
 
+    let filterOptions = null;
+
     if (filter) {
-      const filterOptions = () => {
+      filterOptions = () => {
         const searchTerm = filter.value.trim().toLowerCase();
 
         setActiveOption(-1);
@@ -291,7 +295,7 @@
       }
     };
 
-    listbox.addEventListener('mousemove', (event) => {
+    const handleListboxMouseMove = (event) => {
       const option = event.target.closest('[role="option"]');
       if (option && visibleOptions.includes(option)) {
         const index = options.indexOf(option);
@@ -299,21 +303,16 @@
           setActiveOption(index);
         }
       }
-    });
+    };
 
-    listbox.addEventListener('mouseleave', () => {
+    const handleListboxMouseLeave = () => {
       const selectedOption = listbox.querySelector('[role="option"][aria-selected="true"]');
       if (selectedOption) {
         setActiveOption(options.indexOf(selectedOption));
       } else {
         setActiveOption(-1);
       }
-    });
-
-    trigger.addEventListener('keydown', handleKeyNavigation);
-    if (filter) {
-      filter.addEventListener('keydown', handleKeyNavigation);
-    }
+    };
 
     const openPopover = () => {
       document.dispatchEvent(new CustomEvent('basecoat:popover', {
@@ -340,16 +339,16 @@
       }
     };
 
-    trigger.addEventListener('click', () => {
+    const handleTriggerClick = () => {
       const isExpanded = trigger.getAttribute('aria-expanded') === 'true';
       if (isExpanded) {
         closePopover();
       } else {
         openPopover();
       }
-    });
+    };
 
-    listbox.addEventListener('click', (event) => {
+    const handleListboxClick = (event) => {
       const clickedOption = event.target.closest('[role="option"]');
       if (!clickedOption) return;
 
@@ -370,24 +369,50 @@
         }
         closePopover();
       }
-    });
+    };
 
-    document.addEventListener('click', (event) => {
+    const handleDocumentClick = (event) => {
       if (!selectComponent.contains(event.target)) {
         closePopover(false);
       }
-    });
+    };
 
-    document.addEventListener('basecoat:popover', (event) => {
+    const handleDocumentPopover = (event) => {
       if (event.detail.source !== selectComponent) {
         closePopover(false);
       }
-    });
+    };
+
+    listbox.addEventListener('mousemove', handleListboxMouseMove);
+    listbox.addEventListener('mouseleave', handleListboxMouseLeave);
+    trigger.addEventListener('keydown', handleKeyNavigation);
+    if (filter) {
+      filter.addEventListener('keydown', handleKeyNavigation);
+    }
+    trigger.addEventListener('click', handleTriggerClick);
+    listbox.addEventListener('click', handleListboxClick);
+    document.addEventListener('click', handleDocumentClick);
+    document.addEventListener('basecoat:popover', handleDocumentPopover);
+
+    selectComponent._basecoatSelectDestroy = () => {
+      if (filter) {
+        filter.removeEventListener('input', filterOptions);
+        filter.removeEventListener('keydown', handleKeyNavigation);
+      }
+      listbox.removeEventListener('mousemove', handleListboxMouseMove);
+      listbox.removeEventListener('mouseleave', handleListboxMouseLeave);
+      trigger.removeEventListener('keydown', handleKeyNavigation);
+      trigger.removeEventListener('click', handleTriggerClick);
+      listbox.removeEventListener('click', handleListboxClick);
+      document.removeEventListener('click', handleDocumentClick);
+      document.removeEventListener('basecoat:popover', handleDocumentPopover);
+    };
 
     popover.setAttribute('aria-hidden', 'true');
 
     // Public API
     Object.defineProperty(selectComponent, 'value', {
+      configurable: true,
       get: () => {
         if (isMultiple) {
           return options.filter(opt => selectedOptions.has(opt)).map(getValue);


### PR DESCRIPTION
Adds scoped initialization via initIn allowing for scoped reinitialization instead of full initialization with init/initAll.
It also fixes a couple of select reinit problems. 
- Reinitializing selects no longer crashes when redefining the public value property
- Existing listeners are cleaned up before rebinding so repeated initAll() calls do not leave selects in a broken state

Checked manually:
  - normal auto-init still works
  - initIn() works on a scoped subtree
  - component-filtered init works
  - initAll() no longer breaks multiple selects
  - forced select reinit still keeps the public API working