### PR TITLE
docs(combobox): document form integration with name parameter

### DIFF
--- a/docs/src/components/combobox.njk
+++ b/docs/src/components/combobox.njk
@@ -97,6 +97,10 @@ document.addEventListener('alpine:init', () => {
 
 <div class="prose">
   <p>You can use the <code class="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-xs">select()</code> Nunjucks or Jinja macro for this component. If you use one of the macros, make sure to set <code>is_combobox</code> to <code>True</code> (or <code>true</code> for Nunjucks).</p>
+  <p>
+    To use the combobox in a form, pass a <code>name</code> parameter to the macro. This renders a hidden input that submits the selected value with the form.
+  </p>
+
 </div>
 
 <div class="flex flex-wrap gap-2 my-6">
@@ -115,6 +119,7 @@ document.addEventListener('alpine:init', () => {
 </div>
 
 {% set raw_code %}{% raw %}{% call select(
+  name="framework",
   listbox_attrs={"data-empty": "No framework found."},
   is_combobox=true
 ) %}


### PR DESCRIPTION
## Description

Updates the Combobox component documentation to highlight the `name` parameter and hidden input functionality for form integration.

Changes:
1. Added a paragraph explaining that passing a `name` parameter renders a hidden input that submits the selected value with the form
2. Updated the Jinja/Nunjucks code example to include `name="framework"`

## Related Issue
Closes #154

## Screenshots
N/A — documentation-only change

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/hunvreus/basecoat/blob/main/CONTRIBUTING.md)
- [x] My changes are documentation only, no CSS or JS changes required