### PR TITLE
fix: scoped init, select re-init, iOS zoom, command UX, checkbox indeterminate

### DIFF
--- a/docs/src/llms.txt
+++ b/docs/src/llms.txt
@@ -14,7 +14,7 @@ CDN
 
 JavaScript
 - Auto‑init on `DOMContentLoaded`; observes DOM for new nodes.
-- Manual: `window.basecoat.init('<name>')` or `window.basecoat.initAll()`.
+- Manual: `window.basecoat.init('<name>')`, `window.basecoat.initAll()`, or `window.basecoat.initIn(container, options?)`.
 - Packages to import with ESM: `import 'basecoat-css/all'` or `import 'basecoat-css/tabs'`.
 
 Usage
@@ -81,7 +81,7 @@ Accessibility
 
 Troubleshooting
 - If a component doesn’t work, ensure its JS is loaded and required roles/IDs match examples.
-- For dynamic content, call `window.basecoat.init('<name>')` or `initAll()` after insertion.
+- For dynamic content, call `window.basecoat.init('<name>')`, `window.basecoat.initAll()`, or `window.basecoat.initIn(container, options?)` after insertion.
 
 License
 - MIT (see LICENSE.md)
@@ -126,6 +126,7 @@ import 'basecoat-css/toast';
 ```js
 window.basecoat.init('tabs');
 window.basecoat.initAll();
+window.basecoat.initIn(container, { component: 'tabs' });
 ```
 
 ## Basecoat usage rules
@@ -500,7 +501,7 @@ Additional CSS components include: `progress`, `skeleton`, `slider`, `spinner`, 
 
 ## Troubleshooting
 - If interactivity doesn’t work, ensure the component’s JS is included and required roles/IDs match the examples.
-- For dynamic content, call `window.basecoat.init('<name>')` or `window.basecoat.initAll()` after insertion.
+- For dynamic content, call `window.basecoat.init('<name>')`, `window.basecoat.initAll()`, or `window.basecoat.initIn(container, options?)` after insertion.
 
 ## License
 MIT (see LICENSE.md)

--- a/src/css/basecoat.css
+++ b/src/css/basecoat.css
@@ -42,6 +42,7 @@
   --chevron-down-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="oklch(0.556 0 0)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down-icon lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>'); /* --muted-foreground */
   --chevron-down-icon-50: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="oklch(0.556 0 0 / 0.5)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down-icon lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>'); /* --muted-foreground + 50% opacity */
   --check-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="oklch(0.556 0 0)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-check-icon lucide-check"><path d="M20 6 9 17l-5-5"/></svg>'); /* --muted-foreground */
+  --indeterminate-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="oklch(0.556 0 0)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-minus-icon lucide-minus"><path d="M5 12h14"/></svg>'); /* --muted-foreground */
 }
 
 .dark {
@@ -80,6 +81,7 @@
   --chevron-down-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="oklch(0.708 0 0)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down-icon lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>'); /* --muted-foreground */
   --chevron-down-icon-50: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="oklch(0.708 0 0 / 0.5)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down-icon lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>'); /* --muted-foreground + 50% opacity */
   --check-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="oklch(0.708 0 0)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-check-icon lucide-check"><path d="M20 6 9 17l-5-5"/></svg>');/* --muted-foreground */
+  --indeterminate-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="oklch(0.708 0 0)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-minus-icon lucide-minus"><path d="M5 12h14"/></svg>');/* --muted-foreground */
   color-scheme: dark;
 }
 
@@ -464,6 +466,15 @@
       @apply content-[''] block size-3.5 bg-primary-foreground;
       @apply mask-[image:var(--check-icon)] mask-size-[0.875rem] mask-no-repeat mask-center;
     }
+
+    &:indeterminate {
+      @apply bg-primary border-primary;
+
+      &::after {
+        @apply content-[''] block size-3.5 bg-primary-foreground;
+        @apply mask-(--indeterminate-icon) mask-size-[0.875rem] mask-no-repeat mask-center;
+      }
+    }
   }
 }
 
@@ -556,7 +567,7 @@
         @apply size-4 shrink-0 opacity-50;
       }
       input {
-        @apply placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50;
+        @apply placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-base md:text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50;
       }
     }
     [role='menu'] {
@@ -981,7 +992,7 @@
           @apply size-4 shrink-0 opacity-50;
         }
         input[role='combobox'] {
-          @apply placeholder:text-muted-foreground flex h-10 flex-1 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50 min-w-0;
+          @apply placeholder:text-muted-foreground flex h-10 flex-1 w-full rounded-md bg-transparent py-3 text-base md:text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50 min-w-0;
         }
       }
       [role='listbox']:not(:has([data-value]:not([aria-hidden='true'])))::before {

--- a/src/js/basecoat.js
+++ b/src/js/basecoat.js
@@ -1,6 +1,26 @@
 (() => {
   const componentRegistry = {};
   let observer = null;
+  const NODE_TYPES = {
+    ELEMENT: 1,
+    DOCUMENT: 9,
+    DOCUMENT_FRAGMENT: 11
+  };
+
+  const getScopedElements = (container, selector) => {
+    const elements = [];
+
+    if (
+      container.nodeType === NODE_TYPES.ELEMENT &&
+      typeof container.matches === 'function' &&
+      container.matches(selector)
+    ) {
+      elements.push(container);
+    }
+
+    elements.push(...container.querySelectorAll(selector));
+    return elements;
+  };
 
   const registerComponent = (name, selector, initFunction) => {
     componentRegistry[name] = {
@@ -84,10 +104,50 @@
     initAllComponents();
   };
 
+  const initInScope = (container, options = {}) => {
+    if (
+      !container ||
+      typeof container !== 'object' ||
+      ![
+        NODE_TYPES.ELEMENT,
+        NODE_TYPES.DOCUMENT,
+        NODE_TYPES.DOCUMENT_FRAGMENT
+      ].includes(container.nodeType)
+    ) {
+      console.warn('Invalid container passed to basecoat.initIn()', container);
+      return;
+    }
+
+    const { component: componentName, force = false } = options;
+    const componentNames = componentName ? [componentName] : Object.keys(componentRegistry);
+
+    if (componentName && !componentRegistry[componentName]) {
+      console.warn(`Component '${componentName}' not found in registry`);
+      return;
+    }
+
+    if (force) {
+      componentNames.forEach((name) => {
+        const flag = `data-${name}-initialized`;
+        getScopedElements(container, `[${flag}]`).forEach((element) => {
+          element.removeAttribute(flag);
+        });
+      });
+    }
+
+    componentNames.forEach((name) => {
+      const component = componentRegistry[name];
+      getScopedElements(container, component.selector).forEach((element) => {
+        initComponent(element, name);
+      });
+    });
+  };
+
   window.basecoat = {
     register: registerComponent,
     init: reinitComponent,
     initAll: reinitAll,
+    initIn: initInScope,
     start: startObserver,
     stop: stopObserver
   };

--- a/src/js/command.js
+++ b/src/js/command.js
@@ -150,6 +150,21 @@
       visibleMenuItems[0].scrollIntoView({ block: 'nearest' });
     }
 
+    // Select input text when dialog opens. This makes it easier to type a
+    // new command without having to delete the existing command.
+    const dialog = container.closest('dialog.command-dialog');
+    if (dialog) {
+      const dialogObserver = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+          if (mutation.attributeName === 'open' && dialog.hasAttribute('open')) {
+            input.select();
+            break;
+          }
+        }
+      });
+      dialogObserver.observe(dialog, { attributes: true, attributeFilter: ['open'] });
+    }
+
     container.dataset.commandInitialized = true;
     container.dispatchEvent(new CustomEvent('basecoat:initialized'));
   };

--- a/src/js/select.js
+++ b/src/js/select.js
@@ -17,6 +17,8 @@
       return;
     }
 
+    selectComponent._basecoatSelectDestroy?.();
+
     const allOptions = Array.from(listbox.querySelectorAll('[role="option"]'));
     const options = allOptions.filter(opt => opt.getAttribute('aria-disabled') !== 'true');
     let visibleOptions = [...options];
@@ -161,8 +163,10 @@
       toggleMultipleValue(option);
     };
 
+    let filterOptions = null;
+
     if (filter) {
-      const filterOptions = () => {
+      filterOptions = () => {
         const searchTerm = filter.value.trim().toLowerCase();
 
         setActiveOption(-1);
@@ -295,7 +299,7 @@
       }
     };
 
-    listbox.addEventListener('mousemove', (event) => {
+    const handleListboxMouseMove = (event) => {
       const option = event.target.closest('[role="option"]');
       if (option && visibleOptions.includes(option)) {
         const index = options.indexOf(option);
@@ -303,21 +307,16 @@
           setActiveOption(index);
         }
       }
-    });
+    };
 
-    listbox.addEventListener('mouseleave', () => {
+    const handleListboxMouseLeave = () => {
       const selectedOption = listbox.querySelector('[role="option"][aria-selected="true"]');
       if (selectedOption) {
         setActiveOption(options.indexOf(selectedOption));
       } else {
         setActiveOption(-1);
       }
-    });
-
-    trigger.addEventListener('keydown', handleKeyNavigation);
-    if (filter) {
-      filter.addEventListener('keydown', handleKeyNavigation);
-    }
+    };
 
     const openPopover = () => {
       document.dispatchEvent(new CustomEvent('basecoat:popover', {
@@ -344,16 +343,16 @@
       }
     };
 
-    trigger.addEventListener('click', () => {
+    const handleTriggerClick = () => {
       const isExpanded = trigger.getAttribute('aria-expanded') === 'true';
       if (isExpanded) {
         closePopover();
       } else {
         openPopover();
       }
-    });
+    };
 
-    listbox.addEventListener('click', (event) => {
+    const handleListboxClick = (event) => {
       const clickedOption = event.target.closest('[role="option"]');
       if (!clickedOption) return;
 
@@ -378,24 +377,50 @@
         }
         closePopover();
       }
-    });
+    };
 
-    document.addEventListener('click', (event) => {
+    const handleDocumentClick = (event) => {
       if (!selectComponent.contains(event.target)) {
         closePopover(false);
       }
-    });
+    };
 
-    document.addEventListener('basecoat:popover', (event) => {
+    const handleDocumentPopover = (event) => {
       if (event.detail.source !== selectComponent) {
         closePopover(false);
       }
-    });
+    };
+
+    listbox.addEventListener('mousemove', handleListboxMouseMove);
+    listbox.addEventListener('mouseleave', handleListboxMouseLeave);
+    trigger.addEventListener('keydown', handleKeyNavigation);
+    if (filter) {
+      filter.addEventListener('keydown', handleKeyNavigation);
+    }
+    trigger.addEventListener('click', handleTriggerClick);
+    listbox.addEventListener('click', handleListboxClick);
+    document.addEventListener('click', handleDocumentClick);
+    document.addEventListener('basecoat:popover', handleDocumentPopover);
+
+    selectComponent._basecoatSelectDestroy = () => {
+      if (filter) {
+        filter.removeEventListener('input', filterOptions);
+        filter.removeEventListener('keydown', handleKeyNavigation);
+      }
+      listbox.removeEventListener('mousemove', handleListboxMouseMove);
+      listbox.removeEventListener('mouseleave', handleListboxMouseLeave);
+      trigger.removeEventListener('keydown', handleKeyNavigation);
+      trigger.removeEventListener('click', handleTriggerClick);
+      listbox.removeEventListener('click', handleListboxClick);
+      document.removeEventListener('click', handleDocumentClick);
+      document.removeEventListener('basecoat:popover', handleDocumentPopover);
+    };
 
     popover.setAttribute('aria-hidden', 'true');
 
     // Public API
     Object.defineProperty(selectComponent, 'value', {
+      configurable: true,
       get: () => {
         if (isMultiple) {
           return options.filter(opt => selectedOptions.has(opt)).map(getValue);


### PR DESCRIPTION
Combines 4 open PRs into one reviewable PR:

**#151 (partial) - Scoped re-initialization + select fix**
- Adds `window.basecoat.initIn(container, options?)` for scoped/partial DOM initialization
- Fixes select component re-init issue where event listeners weren't cleaned up
- Critical for htmx/Turbo/Unpoly users

**#153 - Checkbox :indeterminate support**
- Adds `--indeterminate-icon` CSS variable
- Styles `:indeterminate` state on checkboxes

**#139 - iOS auto-zoom fix**
- Changes select and combobox inputs from `text-sm` to `text-base md:text-sm`
- Prevents iOS from auto-zooming on input focus (16px threshold)

**#136 - Command input text selection on re-open**
- Auto-selects input text when command dialog opens
- Makes re-invoking command palette actually useful (existing text doesn't block new typing)

---
Closes #151 (partially), #153, #139, #136