### PR TITLE
fix: prevent iOS auto-zoom on select and combobox inputs

### DIFF
--- a/src/css/basecoat.css
+++ b/src/css/basecoat.css
@@ -556,7 +556,7 @@
         @apply size-4 shrink-0 opacity-50;
       }
       input {
-        @apply placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50;
+        @apply placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-base md:text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50;
       }
     }
     [role='menu'] {
@@ -981,7 +981,7 @@
           @apply size-4 shrink-0 opacity-50;
         }
         input[role='combobox'] {
-          @apply placeholder:text-muted-foreground flex h-10 flex-1 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50 min-w-0;
+          @apply placeholder:text-muted-foreground flex h-10 flex-1 w-full rounded-md bg-transparent py-3 text-base md:text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50 min-w-0;
         }
       }
       [role='listbox']:not(:has([data-value]:not([aria-hidden='true'])))::before {


### PR DESCRIPTION
Changes select and combobox input font-size from `text-sm` to `text-base md:text-sm` to prevent iOS from auto-zooming when the input is focused. iOS only zooms on inputs below 16px.

Closes #139