### PR TITLE
fix(command): auto-select input text when dialog reopens

### DIFF
--- a/src/js/command.js
+++ b/src/js/command.js
@@ -150,6 +150,21 @@
       visibleMenuItems[0].scrollIntoView({ block: 'nearest' });
     }
 
+    // Select input text when dialog opens. This makes it easier to type a
+    // new command without having to delete the existing command.
+    const dialog = container.closest('dialog.command-dialog');
+    if (dialog) {
+      const dialogObserver = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+          if (mutation.attributeName === 'open' && dialog.hasAttribute('open')) {
+            input.select();
+            break;
+          }
+        }
+      });
+      dialogObserver.observe(dialog, { attributes: true, attributeFilter: ['open'] });
+    }
+
     container.dataset.commandInitialized = true;
     container.dispatchEvent(new CustomEvent('basecoat:initialized'));
   };


### PR DESCRIPTION
Adds a MutationObserver on the command component's parent dialog that watches for the `open` attribute. When the dialog opens, it calls `input.select()` so the existing text is selected — making it easy to type a new command without manually clearing the previous one.

Closes #136