### PR TITLE
docs(combobox): document form integration with name parameter

### DIFF
--- a/docs/src/components/combobox.njk
+++ b/docs/src/components/combobox.njk
@@ -178,6 +178,10 @@ toc:
 
 <div class="prose">
   <p>You can use the <code class="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-xs">select()</code> Nunjucks or Jinja macro for this component. If you use one of the macros, make sure to set <code>is_combobox</code> to <code>True</code> (or <code>true</code> for Nunjucks).</p>
+  <p>
+    To use the combobox in a form, pass a <code>name</code> parameter to the macro. This renders a hidden input that submits the selected value with the form.
+  </p>
+
 </div>
 
 <div class="flex flex-wrap gap-2 my-6">
@@ -196,6 +200,7 @@ toc:
 </div>
 
 {% set raw_code %}{% raw %}{% call select(
+  name="framework",
   listbox_attrs={"data-empty": "No framework found."},
   is_combobox=true
 ) %}


### PR DESCRIPTION
Documents how to use the `name` parameter in the combobox macro to render a hidden input that submits the selected value with a form.

Relates to #154