### PR TITLE
fix: set explicit text-foreground on btn-outline and btn-ghost at rest

### DIFF
--- a/src/css/basecoat.css
+++ b/src/css/basecoat.css
@@ -342,7 +342,7 @@
   .btn-icon-outline,
   .btn-sm-icon-outline,
   .btn-lg-icon-outline {
-    @apply border bg-background shadow-xs dark:bg-input/30 dark:border-input;
+    @apply border bg-background text-foreground shadow-xs dark:bg-input/30 dark:border-input;
     &:hover,
     &[aria-pressed='true'] {
       @apply bg-accent text-accent-foreground dark:bg-accent/50;
@@ -354,6 +354,7 @@
   .btn-icon-ghost,
   .btn-sm-icon-ghost,
   .btn-lg-icon-ghost {
+    @apply text-foreground;
     &:hover,
     &[aria-pressed='true'] {
       @apply bg-accent text-accent-foreground dark:bg-accent/50;


### PR DESCRIPTION
Adds `@apply text-foreground` to the rest state of `.btn-outline` and `.btn-ghost` families.

**Problem:** Outline and ghost buttons inherit text color from their parent at rest. When placed inside colored containers (alerts, warning banners, branded sections), the button text picks up the parent's color, which reads as a styling bug.

**Fix:** Add `text-foreground` to the rest-state `@apply` for both `.btn-outline` and `.btn-ghost` variants. The hover state already correctly applies `text-accent-foreground` — this restores symmetry.

Closes #152