### PR TITLE
fix: add input:not([type]) selector for minified HTML files

### DIFF
--- a/src/css/basecoat.css
+++ b/src/css/basecoat.css
@@ -743,6 +743,7 @@
 
 /* Input */
 @layer components {
+  :is(.form, .field) input:not([type]),
   :is(.form, .field) input[type='text']:not(:is(.select [data-popover] > header input[role='combobox'], .command > header input, .dialog > * > header input)),
   :is(.form, .field) input[type='email'],
   :is(.form, .field) input[type='password'],
@@ -756,6 +757,7 @@
   :is(.form, .field) input[type='month'],
   :is(.form, .field) input[type='week'],
   :is(.form, .field) input[type='time'],
+  .input:not([type]),
   .input[type='text'],
   .input[type='email'],
   .input[type='password'],


### PR DESCRIPTION
HTML minifiers like tdewolff/minify remove the default `type='text'` attribute from inputs. Without an explicit type selector, untyped inputs lose their Basecoat styling after minification.

Adds `input:not([type])` alongside the existing typed selectors so inputs without an explicit type still receive the correct styles.

Closes #87