### PR TITLE
fix(tabs): reinitialize when tab children are dynamically changed

### DIFF
--- a/src/js/tabs.js
+++ b/src/js/tabs.js
@@ -1,4 +1,6 @@
 (() => {
+  let tabsInitialized = false;
+
   const initTabs = (tabsComponent) => {
     const tablist = tabsComponent.querySelector('[role="tablist"]');
     if (!tablist) return;
@@ -52,12 +54,67 @@
       selectTab(nextTab);
       nextTab.focus();
     });
-    
+
     tabsComponent.dataset.tabsInitialized = true;
     tabsComponent.dispatchEvent(new CustomEvent('basecoat:initialized'));
   };
 
+  // Watch for tab children changes and reinitialize when tabs change
+  const watchTabsChildren = (tabsComponent) => {
+    const tablist = tabsComponent.querySelector('[role="tablist"]');
+    if (!tablist) return;
+
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.type === 'childList' && mutation.target.getAttribute('role') === 'tablist') {
+          const hasTabsChanges = mutation.addedNodes.length > 0 || mutation.removedNodes.length > 0;
+          if (hasTabsChanges) {
+            tabsComponent.removeAttribute('data-tabs-initialized');
+            initTabs(tabsComponent);
+          }
+        }
+      });
+    });
+
+    observer.observe(tablist, { childList: true, subtree: false });
+  };
+
+  const initAllTabs = () => {
+    document.querySelectorAll('.tabs:not([data-tabs-initialized])').forEach((tabsComponent) => {
+      initTabs(tabsComponent);
+      watchTabsChildren(tabsComponent);
+    });
+    tabsInitialized = true;
+  };
+
   if (window.basecoat) {
-    window.basecoat.register('tabs', '.tabs:not([data-tabs-initialized])', initTabs);
+    window.basecoat.register('tabs', '.tabs:not([data-tabs-initialized])', (el) => {
+      initTabs(el);
+      watchTabsChildren(el);
+    });
+
+    // Override reinit to also re-watch for children changes
+    const originalInit = window.basecoat.init;
+    window.basecoat.init = (componentName) => {
+      if (componentName === 'tabs') {
+        document.querySelectorAll('[data-tabs-initialized]').forEach((el) => {
+          el.removeAttribute('data-tabs-initialized');
+          initTabs(el);
+          watchTabsChildren(el);
+        });
+      } else {
+        originalInit?.(componentName);
+      }
+    };
+  }
+
+  document.addEventListener('basecoat:initialized', () => {
+    if (!tabsInitialized) initAllTabs();
+  });
+
+  if (document.readyState !== 'loading') {
+    initAllTabs();
+  } else {
+    document.addEventListener('DOMContentLoaded', initAllTabs);
   }
 })();


### PR DESCRIPTION
Adds a MutationObserver on the tablist that watches for childList changes. When tabs are added or removed dynamically (via htmx, Turbo, Alpine, etc.), it reinitializes the tabs component by removing the `data-tabs-initialized` flag and re-running initTabs.

Also overrides `window.basecoat.init('tabs')` to re-register the MutationObserver on existing instances.

**Problem:** Once tabs are initialized, dynamically changing the number of tabs has no effect — the component doesn't know the DOM changed.

**Solution:** Watch the tablist for child additions/removals and reinitialize the component when that happens.

Closes #70