### PR TITLE
fix(dialog): prevent close when dragging from inside to outside overlay

### DIFF
--- a/src/jinja/dialog.html.jinja
+++ b/src/jinja/dialog.html.jinja
@@ -48,7 +48,8 @@
   class="dialog {{ dialog_attrs.class }}"
   aria-labelledby="{{ id }}-title"
   {% if description %}aria-describedby="{{ id }}-description"{% endif %}
-  {% if close_on_overlay_click %}onclick="if (event.target === this) this.close()"{% endif %}
+  {% if close_on_overlay_click %}onmousedown="this.dataset.backdropClick = (event.target === this)"
+    onclick="if (event.target === this && this.dataset.backdropClick === 'true') this.close()" {% endif %}
   {% for key, value in dialog_attrs.items() %}
     {% if key != 'class' %}{{ key }}="{{ value }}"{% endif %}
   {% endfor %}

--- a/src/nunjucks/dialog.njk
+++ b/src/nunjucks/dialog.njk
@@ -48,7 +48,8 @@
   class="dialog {{ dialog_attrs.class }}"
   aria-labelledby="{{ id }}-title"
   {% if description %}aria-describedby="{{ id }}-description"{% endif %}
-  {% if close_on_overlay_click %}onclick="if (event.target === this) this.close()"{% endif %}
+  {% if close_on_overlay_click %}onmousedown="this.dataset.backdropClick = (event.target === this)"
+    onclick="if (event.target === this && this.dataset.backdropClick === 'true') this.close()"{% endif %}
   {% for key, value in dialog_attrs %}
     {% if key != 'class' %}{{ key }}="{{ value }}"{% endif %}
   {% endfor %}


### PR DESCRIPTION
Uses `onmousedown` to track whether the click started on the backdrop, then only closes on `onclick` if the mouse-down also started on the backdrop. This prevents the dialog from closing when the user starts a drag inside the dialog and releases outside.

Before: `onclick="if (event.target === this) this.close()"` — fires whenever you click the overlay, including when your mouse-down was inside the dialog.

After: `onmousedown="this.dataset.backdropClick = (event.target === this)" onclick="if (event.target === this && this.dataset.backdropClick === 'true') this.close()"` — only closes if both the mousedown AND the click originated on the overlay.

Closes #104