### PR TITLE
fix(toast): allow targeting specific toaster container via event detail

### DIFF
--- a/src/js/toast.js
+++ b/src/js/toast.js
@@ -165,13 +165,22 @@
   }
 
   document.addEventListener('basecoat:toast', (event) => {
-    if (!toaster) {
-      console.error('Cannot create toast: toaster container not found on page.');
+    const { target, config = {} } = event.detail || {};
+
+    let toasterTarget = toaster;
+    if (target) {
+      toasterTarget = typeof target === 'string'
+        ? document.querySelector(target)
+        : target;
+    }
+
+    if (!toasterTarget) {
+      console.error(`Cannot create toast: toaster container "${target}" not found on page.`);
       return;
     }
-    const config = event.detail?.config || {};
+
     const toastElement = createToast(config);
-    toaster.appendChild(toastElement);
+    toasterTarget.appendChild(toastElement);
   });
 
   if (window.basecoat) {


### PR DESCRIPTION
Adds a `target` field to the `basecoat:toast` event detail. This allows placing a toaster inside a specific container (e.g. inside a dialog element) so toasts render above the dialog instead of behind it.

**Usage:**
```js
// Target a specific toaster by selector
document.dispatchEvent(new CustomEvent('basecoat:toast', {\n  detail: {\n    target: '#my-dialog-toaster',\n    config: { category: 'success', title: 'Saved!' }\n  }\n}));\n\n// Or by passing the element directly\ndocument.dispatchEvent(new CustomEvent('basecoat:toast', {\n  detail: {\n    target: document.querySelector('#my-dialog-toaster'),\n    config: { category: 'success', title: 'Saved!' }\n  }\n}));\n```

Dialog elements use the browser's top layer, which means no z-index can place elements above them. By placing a toaster inside the dialog, toasts naturally render above the dialog's content.

Closes #133