### PR TITLE
fix(table): set explicit border-color on tr to avoid Tailwind reset conflict

### DIFF
--- a/src/css/basecoat.css
+++ b/src/css/basecoat.css
@@ -1151,7 +1151,7 @@
       @apply bg-muted/50 border-t font-medium [&>tr]:last:border-b-0;
     }
     tr {
-      @apply hover:bg-muted/50 border-b transition-colors;
+      @apply hover:bg-muted/50 border-b border-border transition-colors;
     }
     th {
       @apply text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px];


### PR DESCRIPTION
Tailwind's base reset sets `* { border: 0 solid }` which strips inherited border-color. Adding `border-border` to `tr` ensures table rows always have visible borders regardless of any CSS reset conflicts.

Also applies to `.btn-icon-outline` and other elements that rely on inherited border-color, as noted in #58.

Closes #58