### PR TITLE
fix(dropdown): add z-10 to popover to fix stacking above table buttons

### DIFF
--- a/src/css/basecoat.css
+++ b/src/css/basecoat.css
@@ -664,7 +664,7 @@
     @apply relative inline-flex;
 
     [data-popover] {
-      @apply p-1;
+      @apply p-1 relative z-10;
       min-width: anchor-size(width);
 
       [role='menuitem'],


### PR DESCRIPTION
When a dropdown menu is placed inside a table row, other buttons in adjacent rows can render above the dropdown menu due to stacking context conflicts.

Adding `relative z-10` to `[data-popover]` ensures the dropdown popover stacks above sibling table buttons.

Ronan mentioned this fix in the issue thread: "Try and apply a `z-10` or `z-20` to the dropdown popover."

Closes #114