### PR TITLE
feat(command): add async search support with commandAsync API

### DIFF
--- a/src/js/command.js
+++ b/src/js/command.js
@@ -1,4 +1,46 @@
 (() => {
+  const asyncRegistry = {};
+  const searchControllers = {};
+
+  const defaultAsyncConfig = {
+    minLength: 1,
+    debounce: 150,
+    maxResults: 8,
+    renderItem: null
+  };
+
+  const getUtils = () => window.basecoat?.utils || {};
+
+  const defaultRenderItem = (item, id) => {
+    const { escapeHtml, isValidUrl } = getUtils();
+    const tag = item.url && isValidUrl?.(item.url) ? 'a' : 'div';
+    const href = tag === 'a' ? ` href="${escapeHtml?.(item.url) || ''}"` : '';
+    const keywords = item.keywords ? ` data-keywords="${escapeHtml?.(item.keywords) || ''}"` : '';
+    const label = escapeHtml?.(item.label) || item.label || '';
+    const icon = item.icon || '';
+    return `<${tag} id="${id}" role="menuitem"${href}${keywords}>${icon}${label}</${tag}>`;
+  };
+
+  const setState = (container, state, message = '') => {
+    container.dataset.state = state;
+    const menu = container.querySelector('[role="menu"]');
+    if (menu) {
+      if (state === 'error' && message) {
+        menu.dataset.error = message;
+      } else {
+        delete menu.dataset.error;
+      }
+    }
+  };
+
+  const debounce = (fn, ms) => {
+    let timer;
+    return (...args) => {
+      clearTimeout(timer);
+      timer = setTimeout(() => fn(...args), ms);
+    };
+  };
+
   const initCommand = (container) => {
     const input = container.querySelector('header input');
     const menu = container.querySelector('[role="menu"]');
@@ -11,23 +53,29 @@
       return;
     }
 
-    const allMenuItems = Array.from(menu.querySelectorAll('[role="menuitem"]'));
-    const menuItems = allMenuItems.filter(item => 
-      !item.hasAttribute('disabled') && 
+    const isAsync = container.dataset.commandAsync === 'true';
+    const commandId = container.id || container.dataset.commandId;
+    const asyncConfig = isAsync && commandId ? asyncRegistry[commandId] : null;
+
+    if (isAsync && !asyncConfig) {
+      return;
+    }
+
+    let allMenuItems = Array.from(menu.querySelectorAll('[role="menuitem"]'));
+    let menuItems = allMenuItems.filter(item =>
+      !item.hasAttribute('disabled') &&
       item.getAttribute('aria-disabled') !== 'true'
     );
     let visibleMenuItems = [...menuItems];
     let activeIndex = -1;
 
     const setActiveItem = (index) => {
-      if (activeIndex > -1 && menuItems[activeIndex]) {
-        menuItems[activeIndex].classList.remove('active');
-      }
+      container.querySelector('[role="menuitem"].active')?.classList.remove('active');
 
       activeIndex = index;
 
-      if (activeIndex > -1) {
-        const activeItem = menuItems[activeIndex];
+      if (activeIndex > -1 && visibleMenuItems[activeIndex]) {
+        const activeItem = visibleMenuItems[activeIndex];
         activeItem.classList.add('active');
         if (activeItem.id) {
           input.setAttribute('aria-activedescendant', activeItem.id);
@@ -39,6 +87,15 @@
       }
     };
 
+    const refreshMenuItems = () => {
+      allMenuItems = Array.from(menu.querySelectorAll('[role="menuitem"]'));
+      menuItems = allMenuItems.filter(item =>
+        !item.hasAttribute('disabled') &&
+        item.getAttribute('aria-disabled') !== 'true'
+      );
+      visibleMenuItems = [...menuItems];
+    };
+
     const filterMenuItems = () => {
       const searchTerm = input.value.trim().toLowerCase();
 
@@ -46,21 +103,9 @@
 
       visibleMenuItems = [];
       allMenuItems.forEach(item => {
-        if (item.hasAttribute('data-force')) {
-          item.setAttribute('aria-hidden', 'false');
-          if (menuItems.includes(item)) {
-            visibleMenuItems.push(item);
-          }
-          return;
-        }
-
-        const itemText = (item.dataset.filter || item.textContent).trim().toLowerCase();
-        const keywordList = (item.dataset.keywords || '')
-          .toLowerCase()
-          .split(/[\s,]+/)
-          .filter(Boolean);
-        const matchesKeyword = keywordList.some(keyword => keyword.includes(searchTerm));
-        const matches = itemText.includes(searchTerm) || matchesKeyword;
+        const itemText = (item.dataset.label || item.textContent).trim().toLowerCase();
+        const keywords = (item.dataset.keywords || '').toLowerCase();
+        const matches = itemText.includes(searchTerm) || keywords.includes(searchTerm);
         item.setAttribute('aria-hidden', String(!matches));
         if (matches && menuItems.includes(item)) {
           visibleMenuItems.push(item);
@@ -68,12 +113,76 @@
       });
 
       if (visibleMenuItems.length > 0) {
-        setActiveItem(menuItems.indexOf(visibleMenuItems[0]));
+        setActiveItem(0);
         visibleMenuItems[0].scrollIntoView({ block: 'nearest' });
       }
     };
 
-    input.addEventListener('input', filterMenuItems);
+    const performAsyncSearch = async (query) => {
+      const id = commandId;
+
+      if (searchControllers[id]) {
+        searchControllers[id].abort();
+      }
+      searchControllers[id] = new AbortController();
+
+      if (query.length < asyncConfig.minLength) {
+        menu.innerHTML = '';
+        setState(container, 'idle');
+        return;
+      }
+
+      setState(container, 'loading');
+
+      try {
+        const results = await asyncConfig.onSearch(query, searchControllers[id].signal);
+
+        if (searchControllers[id]?.signal.aborted) return;
+
+        if (!results || results.length === 0) {
+          menu.innerHTML = '';
+          setState(container, 'empty');
+        } else {
+          const items = results.slice(0, asyncConfig.maxResults);
+          const renderFn = asyncConfig.renderItem || defaultRenderItem;
+          menu.innerHTML = items.map((item, i) => renderFn(item, `${id}-result-${i}`)).join('');
+          setState(container, 'results');
+
+          refreshMenuItems();
+
+          if (visibleMenuItems.length > 0) {
+            setActiveItem(0);
+            visibleMenuItems[0].scrollIntoView({ block: 'nearest' });
+          }
+        }
+
+        container.dispatchEvent(new CustomEvent('command:search', {
+          bubbles: true,
+          detail: { query, results: results || [] }
+        }));
+      } catch (error) {
+        if (error.name === 'AbortError') return;
+        console.error('Command async search error:', error);
+        menu.innerHTML = '';
+        setState(container, 'error', error.message || 'Search failed');
+      } finally {
+        delete searchControllers[id];
+      }
+    };
+
+    if (isAsync && asyncConfig) {
+      const debounceMs = parseInt(container.dataset.commandDebounce, 10) || asyncConfig.debounce;
+      const debouncedSearch = debounce(performAsyncSearch, debounceMs);
+
+      setState(container, 'idle');
+
+      input.addEventListener('input', () => {
+        const query = input.value.trim();
+        debouncedSearch(query);
+      });
+    } else {
+      input.addEventListener('input', filterMenuItems);
+    }
 
     const handleKeyNavigation = (event) => {
       if (!['ArrowDown', 'ArrowUp', 'Enter', 'Home', 'End'].includes(event.key)) {
@@ -82,8 +191,8 @@
 
       if (event.key === 'Enter') {
         event.preventDefault();
-        if (activeIndex > -1) {
-          menuItems[activeIndex]?.click();
+        if (activeIndex > -1 && visibleMenuItems[activeIndex]) {
+          visibleMenuItems[activeIndex].click();
         }
         return;
       }
@@ -92,41 +201,41 @@
 
       event.preventDefault();
 
-      const currentVisibleIndex = activeIndex > -1 ? visibleMenuItems.indexOf(menuItems[activeIndex]) : -1;
-      let nextVisibleIndex = currentVisibleIndex;
+      let nextIndex = activeIndex;
 
       switch (event.key) {
         case 'ArrowDown':
-          if (currentVisibleIndex < visibleMenuItems.length - 1) {
-            nextVisibleIndex = currentVisibleIndex + 1;
+          if (activeIndex < visibleMenuItems.length - 1) {
+            nextIndex = activeIndex + 1;
+          } else if (activeIndex === -1) {
+            nextIndex = 0;
           }
           break;
         case 'ArrowUp':
-          if (currentVisibleIndex > 0) {
-            nextVisibleIndex = currentVisibleIndex - 1;
-          } else if (currentVisibleIndex === -1) {
-            nextVisibleIndex = 0;
+          if (activeIndex > 0) {
+            nextIndex = activeIndex - 1;
+          } else if (activeIndex === -1) {
+            nextIndex = visibleMenuItems.length - 1;
           }
           break;
         case 'Home':
-          nextVisibleIndex = 0;
+          nextIndex = 0;
           break;
         case 'End':
-          nextVisibleIndex = visibleMenuItems.length - 1;
+          nextIndex = visibleMenuItems.length - 1;
           break;
       }
 
-      if (nextVisibleIndex !== currentVisibleIndex) {
-        const newActiveItem = visibleMenuItems[nextVisibleIndex];
-        setActiveItem(menuItems.indexOf(newActiveItem));
-        newActiveItem.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      if (nextIndex !== activeIndex && nextIndex >= 0) {
+        setActiveItem(nextIndex);
+        visibleMenuItems[nextIndex].scrollIntoView({ block: 'nearest', behavior: 'smooth' });
       }
     };
 
     menu.addEventListener('mousemove', (event) => {
       const menuItem = event.target.closest('[role="menuitem"]');
       if (menuItem && visibleMenuItems.includes(menuItem)) {
-        const index = menuItems.indexOf(menuItem);
+        const index = visibleMenuItems.indexOf(menuItem);
         if (index !== activeIndex) {
           setActiveItem(index);
         }
@@ -145,16 +254,40 @@
 
     input.addEventListener('keydown', handleKeyNavigation);
 
-    if (visibleMenuItems.length > 0) {
-      setActiveItem(menuItems.indexOf(visibleMenuItems[0]));
+    if (!isAsync && visibleMenuItems.length > 0) {
+      setActiveItem(0);
       visibleMenuItems[0].scrollIntoView({ block: 'nearest' });
     }
 
-    container.dataset.commandInitialized = true;
+    container.dataset.commandInitialized = 'true';
     container.dispatchEvent(new CustomEvent('basecoat:initialized'));
+  };
+
+  const findCommandById = (id) => {
+    return document.getElementById(id) || document.querySelector(`[data-command-id="${id}"]`);
+  };
+
+  const registerAsync = (id, config) => {
+    asyncRegistry[id] = { ...defaultAsyncConfig, ...config };
+
+    const container = findCommandById(id);
+    if (container && container.dataset.commandAsync === 'true' && !container.dataset.commandInitialized) {
+      initCommand(container);
+    }
   };
 
   if (window.basecoat) {
     window.basecoat.register('command', '.command:not([data-command-initialized])', initCommand);
+
+    window.basecoat.commandAsync = {
+      register: registerAsync,
+      initAll: () => {
+        document.querySelectorAll('.command[data-command-async="true"]:not([data-command-initialized])').forEach(container => {
+          if (container.id && asyncRegistry[container.id]) {
+            initCommand(container);
+          }
+        });
+      }
+    };
   }
 })();


### PR DESCRIPTION
Adds full async search capability to the Command component, enabling dynamic data sources like API-backed search.

**New features:**
- `data-command-async="true"` attribute on `.command` elements to enable async mode
- `window.basecoat.commandAsync.register(id, config)` for registering search handlers
- `window.basecoat.commandAsync.initAll()` for bulk initialization

**Config options:**
- `minLength` (default 1) — minimum characters before searching
- `debounce` (default 150ms) — delay before firing search
- `maxResults` (default 8) — max results to render
- `onSearch(query, signal)` — async function returning results array
- `renderItem(item, id)` — optional custom render function

**States:**
- `dataset.state = 'idle'` — waiting for input
- `dataset.state = 'loading'` — fetching results
- `dataset.state = 'results'` — results displayed
- `dataset.state = 'empty'` — no results found
- `dataset.state = 'error'` — search failed

**Usage example:**
```js
window.basecoat.commandAsync.register('site-search', {
  minLength: 2,
  debounce: 150,
  maxResults: 8,
  onSearch: async (query, signal) => {
    const results = await searchAPI(query);
    return results; // [{ label, url, excerpt, icon? }]
  }
});
```

Closes #127