### PR TITLE
feat(select): add multiselect support with multi-select threshold and badge display

### DIFF
--- a/docs/src/_includes/partials/kitchen-sink/form.njk
+++ b/docs/src/_includes/partials/kitchen-sink/form.njk
@@ -1,6 +1,9 @@
 <section id="form" class="w-full rounded-lg border scroll-mt-16">
   <header class="border-b px-4 py-3">
     <h2 class="text-sm font-medium">Form</h2>
+    <a href="/components/form" class="text-muted-foreground hover:text-foreground" data-tooltip="See documentation" data-side="left">
+      {% lucide "book-open", { "class": "size-4" }   %}
+    </a>
   </header>
   <div class="p-4">
     <form class="form grid w-full max-w-sm gap-6">

--- a/docs/src/components/select.njk
+++ b/docs/src/components/select.njk
@@ -32,8 +32,6 @@ toc:
         id: example-disabled
       - label: With icon
         id: example-with-icon
-      - label: Multiple
-        id: example-multiple
 ---
 
 {% from "macros/code_preview.njk" import code_preview %}
@@ -63,7 +61,7 @@ toc:
         { type: "item", value: "apple", label: "Apple" },
         { type: "item", value: "banana", label: "Banana" },
         { type: "item", value: "blueberry", label: "Blueberry" },
-        { type: "item", value: "grapes", label: "Grapes" },
+        { type: "item", value: "pineapple", label: "Grapes" },
         { type: "item", value: "pineapple", label: "Pineapple" }
       ]
     }
@@ -122,70 +120,44 @@ toc:
 <section class="prose">
   <dl>
     <dt><code class="highlight language-html">&lt;div class="select"&gt;</code></dt>
-    <dd>
-      <p>Wraps around the entire component. Can have the following attributes:</p>
-      <ul>
-        <li><code>data-placeholder="{ TEXT }"</code> <span class="badge-secondary">Optional</span>: placeholder text shown when no options are selected (multiselect only).</li>
-        <li><code>data-close-on-select="true"</code> <span class="badge-secondary">Optional</span>: closes the popover when selecting an option in multiselect mode.</li>
-      </ul>
+    <dd>Wraps around the entire component.
       <dl>
-        <dt><code class="highlight language-html">&lt;button type="button"&gt;</code></dt>
+        <dt><code class="highlight language-html">&lt;button type="button" popovertarget="{ POPOVER_ID }"&gt;</code></dt>
         <dd>
-          <p>The trigger to open the popover. Should have the following attributes:</p>
+          <p>The trigger to open the popover, can also have the following attributes:</p>
           <ul>
             <li><code>id="{BUTTON_ID}"</code>: linked to by the <code>aria-labelledby</code> attribute of the listbox.</li>
             <li><code>aria-haspopup="listbox"</code>: indicates that the button opens a listbox.</li>
             <li><code>aria-controls="{ LISTBOX_ID }"</code>: points to the listbox's id.</li>
             <li><code>aria-expanded="false"</code>: tracks the popover's state.</li>
-            <li><code>aria-activedescendant="{ OPTION_ID }"</code> <span class="badge-secondary">Optional</span>: points to the active option's id.</li>
+            <li><code>aria-activedescendant="{ OPTION_ID }"</code>: points to the active option's id.</li>
           </ul>
         </dd>
-        <dt><code class="highlight language-html">&lt;div data-popover aria-hidden="true" id="{ POPOVER_ID }"&gt;</code></dt>
-        <dd>The popover content. You can set up the side and alignment using the <code>data-side</code> and <code>data-align</code> attributes (see <a href="/components/popover">Popover</a> component).
+        <dt><code class="highlight language-html">&lt;div popover class="popover" id="{ POPOVER_ID }"&gt;</code></dt>
+        <dd>As with the <a href="/components/popover">Popover</a> component, you can set up the side and alignment of the popover using the <code>data-side</code> and <code>data-align</code> attributes.
         <dl>
           <dt><code class="highlight language-html">&lt;div role="listbox"&gt;</code></dt>
-          <dd>
-            <p>The listbox containing the options. Should have the following attributes:</p>
+          <dd>The listbox containing the options. Should have the following attributes:
             <ul>
               <li><code>id="{ LISTBOX_ID }"</code>: refered to by the <code>aria-controls</code> attribute of the trigger.</li>
               <li><code>aria-labelledby="{ BUTTON_ID }"</code>: linked to by the button's <code>id</code> attribute.</li>
-              <li><code>aria-multiselectable="true"</code> <span class="badge-secondary">Optional</span>: enables multiple selection mode.</li>
             </ul>
             <dl>
               <dt><code class="highlight language-html">&lt;div role="option" data-value="{ VALUE }"&gt;</code></dt>
-              <dd>
-                <p>Option that can be selected. Should have the following attributes:</p>
-                <ul>
-                  <li><code>id="{ OPTION_ID }"</code> <span class="badge-secondary">Optional</span>: unique id for this option (needed if you use <code>aria-activedescendant</code> on the trigger).</li>
-                  <li><code>data-value="{ VALUE }"</code>: the value for this option.</li>
-                  <li><code>data-label="{ LABEL }"</code> <span class="badge-secondary">Optional</span>: the text label to use for this option when selected in multiple mode. If not provided, the option's text content will be used (HTML stripped).</li>
-                  <li><code>aria-selected="true"</code> <span class="badge-secondary">Optional</span>: indicates this option is selected.</li>
-                </ul>
-              </dd>
+              <dd>Option that can be selected.Should have a unique id if you use the <code>aria-activedescendant</code> attribute on the trigger.</dd>
               <dt><code class="highlight language-html">&lt;hr role="separator"&gt;</code> <span class="badge-secondary">Optional</span></dt>
               <dd>Separator between groups/options.</dd>
               <dt><code class="highlight language-html">&lt;div role="group"&gt;</code> <span class="badge-secondary">Optional</span></dt>
               <dd>Group of options, can have a <code>aria-labelledby</code> attribute to link to a heading.</dd>
-              <dt><code class="highlight language-html">&lt;span role="heading"&gt;</code> <span class="badge-secondary">Optional</span></dt>
+              <dt><code class="highlight language-html">&lt;span role="heading"&gt;</code></dt>
               <dd>Group heading, must have an <code>id</code> attribute if you use the <code>aria-labelledby</code> attribute on the group.</dd>
             </dl>
           </dd>
         </dl>
       </dl>
     </dd>
-    <dt><code class="highlight language-html">&lt;input type="hidden" name="{ NAME }" value="{ VALUE }"&gt;</code></dt>
-    <dd>
-      <p>The hidden input that holds the selected value.</p>
-      <p>For single-select: contains the selected option's value as a string.</p>
-      <p>For multiselect: contains a <strong>JSON array</strong> of selected values (e.g., <code>["apple","banana"]</code>). When no options are selected, contains an empty array (<code>[]</code>).</p>
-      <p><strong>Backend handling:</strong> Parse the JSON value on the server side. For example:</p>
-      <ul>
-        <li><strong>Python/Flask:</strong> <code>values = json.loads(request.form.get('field', '[]'))</code></li>
-        <li><strong>PHP:</strong> <code>$values = json_decode($_POST['field'] ?? '[]', true);</code></li>
-        <li><strong>Node.js:</strong> <code>const values = JSON.parse(req.body.field || '[]');</code></li>
-        <li><strong>Ruby/Rails:</strong> <code>values = JSON.parse(params[:field] || '[]')</code></li>
-      </ul>
-    </dd>
+    <dt><code class="highlight language-html">&lt;input type="hidden" name="{ NAME }" value="{ VALUE }"&gt;</code> <span class="badge-secondary">Optional</span></dt>
+    <dd>The hidden input that holds the value of the field (if needed).</dd>
   </dl>
 </section>
 
@@ -198,103 +170,25 @@ toc:
     <dt><code>basecoat:popover</code></dt>
     <dd>When the popover opens, the component dispatches a custom (non-bubbling) <code>basecoat:popover</code> event on <code>document</code>. Other popover components (Combobox, Dropdown Menu, Popover and Select) listen for this to close any open popovers.</dd>
     <dt><code>change</code></dt>
-    <dd>
-      <p>When the selected value changes, the component dispatches a custom (bubbling) <code>change</code> event on itself, with the selected value in <code>event.detail.value</code>:</p>
-      <ul>
-        <li>Single select: <code>{ detail: { value: "something" }}</code> (string)</li>
-        <li>Multiple select: <code>{ detail: { value: ["item1", "item2"] }}</code> (array)</li>
-      </ul>
-    </dd>
+    <dd>When the selected value changes, the component dispatches a custom (bubbling) <code>change</code> event on itself, with the selected value in <code>event.detail</code> (e.g. <code>{ detail: { value: "something" }}</code>).</dd>
   </dl>
 </section>
 
-<h4 id="usage-html-js-5"><a href="#usage-html-js-5">JavaScript methods and properties</a></h4>
+<h4 id="usage-html-js-5"><a href="#usage-html-js-5">JavaScript methods</a></h4>
 
 <section class="prose">
   <dl>
-    <dt><code>value</code> (property)</dt>
+    <dt><code>selectByValue</code></dt>
     <dd>
-      <p>Get or set the current value. For single-select, this is a string. For multiselect, this is an array. The multiselect setter accepts both strings and arrays.</p>
+      <p>You can call this method on the component after it is initialized to select an option by value (i.e. the option with the matching <code>data-value</code> attribute):</p>
 
-{% set code_value %}<script>
+{% set code_script %}<script>
   const selectComponent = document.querySelector('#my-select');
   selectComponent.addEventListener('basecoat:initialized', () => {
-    // Get value
-    console.log(selectComponent.value); // 'apple'
-
-    // Set value (single-select)
-    selectComponent.value = 'banana';
-
-    // Set value (multiselect - accepts string or array)
-    selectComponent.value = ['apple', 'banana'];
-    selectComponent.value = 'apple'; // normalized to ['apple']
+    selectComponent.selectByValue('apple');
   });
 </script>{% endset %}
-{{ code_block(code_value | prettyHtml, "html") }}
-    </dd>
-    <dt><code>select(value)</code></dt>
-    <dd>
-      <p>Selects an option by value (i.e. the option with the matching <code>data-value</code> attribute). For single-select, this will close the popover. For multiselect, this adds the value to the selection if not already selected.</p>
-
-{% set code_select %}<script>
-  const selectComponent = document.querySelector('#my-select');
-  selectComponent.addEventListener('basecoat:initialized', () => {
-    selectComponent.select('apple');
-  });
-</script>{% endset %}
-{{ code_block(code_select | prettyHtml, "html") }}
-    </dd>
-    <dt><code>deselect(value)</code> <span class="badge-secondary">Multiselect only</span></dt>
-    <dd>
-      <p>Removes a specific value from the selection. Only available when the component is in multiselect mode (<code>aria-multiselectable="true"</code>).</p>
-
-{% set code_deselect %}<script>
-  const selectComponent = document.querySelector('#my-multiselect');
-  selectComponent.addEventListener('basecoat:initialized', () => {
-    selectComponent.deselect('apple');
-  });
-</script>{% endset %}
-{{ code_block(code_deselect | prettyHtml, "html") }}
-    </dd>
-    <dt><code>toggle(value)</code> <span class="badge-secondary">Multiselect only</span></dt>
-    <dd>
-      <p>Toggles a specific value in the selection (adds if not present, removes if present). Only available when the component is in multiselect mode (<code>aria-multiselectable="true"</code>).</p>
-
-{% set code_toggle %}<script>
-  const selectComponent = document.querySelector('#my-multiselect');
-  selectComponent.addEventListener('basecoat:initialized', () => {
-    selectComponent.toggle('apple'); // adds if not selected, removes if selected
-  });
-</script>{% endset %}
-{{ code_block(code_toggle | prettyHtml, "html") }}
-    </dd>
-    <dt><code>selectAll()</code> <span class="badge-secondary">Multiselect only</span></dt>
-    <dd>
-      <p>Selects all available options. Only available when the component is in multiselect mode (<code>aria-multiselectable="true"</code>).</p>
-
-{% set code_script_all %}<script>
-  const selectComponent = document.querySelector('#my-multiselect');
-  selectComponent.addEventListener('basecoat:initialized', () => {
-    selectComponent.selectAll();
-  });
-</script>{% endset %}
-{{ code_block(code_script_all | prettyHtml, "html") }}
-    </dd>
-    <dt><code>selectNone()</code> <span class="badge-secondary">Multiselect only</span></dt>
-    <dd>
-      <p>Deselects all options. Only available when the component is in multiselect mode (<code>aria-multiselectable="true"</code>).</p>
-
-{% set code_script_none %}<script>
-  const selectComponent = document.querySelector('#my-multiselect');
-  selectComponent.addEventListener('basecoat:initialized', () => {
-    selectComponent.selectNone();
-  });
-</script>{% endset %}
-{{ code_block(code_script_none | prettyHtml, "html") }}
-    </dd>
-    <dt><code>selectByValue(value)</code></dt>
-    <dd>
-      <p><strong>Deprecated:</strong> Alias for <code>select(value)</code>. Kept for backward compatibility.</p>
+{{ code_block(code_script | prettyHtml, "html") }}
     </dd>
   </dl>
 </section>
@@ -310,11 +204,11 @@ toc:
     Use Nunjucks or Jinja macros
     {% lucide "arrow-right" %}
   </a>
-  <a class="badge-outline" href="https://github.com/hunvreus/basecoat/blob/main/src/jinja/select.html.jinja" target="_blank">
+  <a class="badge-outline" href="https://github.com/hunvreus/basecoat/blob/main/src/jinja/dialog.html.jinja" target="_blank">
     Jinja macro
     {% lucide "arrow-right" %}
   </a>
-  <a class="badge-outline" href="https://github.com/hunvreus/basecoat/blob/main/src/nunjucks/select.njk" target="_blank">
+  <a class="badge-outline" href="https://github.com/hunvreus/basecoat/blob/main/src/nunjucks/dialog.njk" target="_blank">
     Nunjucks macro
     {% lucide "arrow-right" %}
   </a>
@@ -365,23 +259,6 @@ toc:
 
 {{ code_preview("select-disabled", code | prettyHtml) }}
 
-<h3 id="example-invalid-state"><a href="#example-invalid-state">Invalid State</a></h3>
-
-{% set code %}
-{{ select(
-  trigger_attrs={"aria-invalid": "true"},
-  items=[
-    { value: "", label: "Select a role" },
-    { value: "admin", label: "Admin" },
-    { value: "editor", label: "Editor" },
-    { value: "viewer", label: "Viewer" },
-    { value: "guest", label: "Guest" }
-  ]
-) }}
-{% endset %}
-
-{{ code_preview("select-disabled", code | prettyHtml) }}
-
 <h3 id="example-with-icon"><a href="#example-with-icon">With icon</a></h3>
 
 {% set code %}
@@ -410,48 +287,4 @@ toc:
 {% endcall %}
 {% endset %}
 
-{{ code_preview("select-with-icons", code | prettyHtml) }}
-
-<h3 id="example-multiple"><a href="#example-multiple">Multiple</a></h3>
-
-<section class="prose">
-  <p>Enable multiple selection by setting adding <code>aria-multiselectable="true"</code> to the <code>listbox</code>. The selected options are displayed as a comma-separated list in the trigger button. Use <code>data-label</code> to specify clean text labels for options that contain HTML (like icons), otherwise the text content will be extracted automatically.</p>
-</section>
-
-{% set code %}
-{% call select(
-  id="select-multiple",
-  name="chart-types",
-  multiple=true,
-  placeholder="Select chart types...",
-  selected=["bar", "line"],
-  trigger_attrs={"class": "w-[220px]"}
-) %}
-<div role="option" data-value="bar" data-label="Bar">
-  <span class="flex items-center gap-2">
-    {% lucide "chart-bar", {"class": "text-muted-foreground"} %}
-    Bar
-  </span>
-</div>
-<div role="option" data-value="line" data-label="Line">
-  <span class="flex items-center gap-2">
-    {% lucide "chart-line", {"class": "text-muted-foreground"} %}
-    Line
-  </span>
-</div>
-<div role="option" data-value="pie" data-label="Pie">
-  <span class="flex items-center gap-2">
-    {% lucide "chart-pie", {"class": "text-muted-foreground"} %}
-    Pie
-  </span>
-</div>
-<div role="option" data-value="area" data-label="Area">
-  <span class="flex items-center gap-2">
-    {% lucide "chart-area", {"class": "text-muted-foreground"} %}
-    Area
-  </span>
-</div>
-{% endcall %}
-{% endset %}
-
-{{ code_preview("select-multiple", code | prettyHtml) }}
+{{ code_preview("select-scrollable", code | prettyHtml) }}

--- a/src/jinja/select.html.jinja
+++ b/src/jinja/select.html.jinja
@@ -2,11 +2,8 @@
   Renders a select or combobox component.
 
   @param id {string} [optional] - Unique identifier for the select component.
-  @param selected {string|array} [optional] - The initially selected value(s).
+  @param selected {string} [optional] - The initially selected value.
   @param name {string} [optional] - The name attribute for the hidden input storing the selected value.
-  @param multiple {boolean} [optional] [default=false] - Enables multiple selection mode.
-  @param placeholder {string} [optional] - Placeholder text shown when no options are selected (multiple mode only).
-  @param close_on_select {boolean} [optional] [default=false] - Closes the popover when selecting an option in multiple mode.
   @param main_attrs {object} [optional] - Additional HTML attributes for the main container div.
   @param trigger_attrs {object} [optional] - Additional HTML attributes for the trigger button.
   @param popover_attrs {object} [optional] - Additional HTML attributes for the popover content div.
@@ -20,9 +17,6 @@
   selected=None,
   name=None,
   items=[],
-  multiple=false,
-  placeholder=None,
-  close_on_select=false,
   main_attrs={},
   trigger_attrs={},
   popover_attrs={},
@@ -33,59 +27,43 @@
 ) %}
 {% set id = id or ("select-" + (range(100000, 999999) | random | string)) %}
 
-{% if selected is defined and selected is iterable and selected is not string %}
-  {% set selectedArray = selected %}
-{% elif selected is defined %}
-  {% set selectedArray = [selected] %}
-{% else %}
-  {% set selectedArray = [] %}
-{% endif %}
 {% set first_option = namespace(item=None) %}
-{% set selected_options = namespace(items=[]) %}
+{% set selected_option = namespace(item=None) %}
 
 {% if items %}
   {% for item in items %}
     {% if item.type == "group" %}
-      {% for sub_item in item['items'] %}
+      {% for sub_item in item.items %}
         {% if not first_option.item %}
           {% set first_option.item = sub_item %}
         {% endif %}
-        {% if sub_item.value in selectedArray %}
-          {% set selected_options.items = selected_options.items + [sub_item] %}
+        {% if selected and sub_item.value == selected and not selected_option.item %}
+          {% set selected_option.item = sub_item %}
         {% endif %}
       {% endfor %}
     {% else %}
       {% if not first_option.item %}
         {% set first_option.item = item %}
       {% endif %}
-      {% if item.value in selectedArray %}
-        {% set selected_options.items = selected_options.items + [item] %}
+      {% if selected and item.value == selected and not selected_option.item %}
+        {% set selected_option.item = item %}
       {% endif %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
-{% set default_option = (selected_options.items[0] if selected_options.items else first_option.item) %}
-{% set labels = [] %}
-{% if multiple and selected_options.items %}
-  {% for opt in selected_options.items %}
-    {% set labels = labels + [opt.label] %}
-  {% endfor %}
-{% endif %}
-{% set default_label = (', '.join(labels) if (multiple and selected_options.items) else ((placeholder or '') if (multiple and not selected_options.items) else (default_option.label if default_option else ''))) %}
+{% set default_option = selected_option.item or first_option.item or None %}
 
 <div
   id="{{ id }}"
   class="select {{ main_attrs.class }}"
-  {% if multiple and placeholder %}data-placeholder="{{ placeholder }}"{% endif %}
-  {% if multiple and close_on_select %}data-close-on-select="true"{% endif %}
   {% for key, value in main_attrs.items() %}
     {% if key != 'class' %}{{ key }}="{{ value }}"{% endif %}
   {% endfor %}
 >
   <button
     type="button"
-    class="btn-outline {{ trigger_attrs.class }}"
+    class="btn-outline justify-between font-normal {{ trigger_attrs.class }}"
     id="{{ id }}-trigger"
     aria-haspopup="listbox"
     aria-expanded="false"
@@ -94,7 +72,7 @@
       {% if key != 'class' %}{{ key }}="{{ value }}"{% endif %}
     {% endfor %}
   >
-    <span class="truncate">{{ default_label }}</span>
+    <span class="truncate">{{ default_option.label }}</span>
     {% if is_combobox %}
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevrons-up-down-icon lucide-chevrons-up-down text-muted-foreground opacity-50 shrink-0"><path d="m7 15 5 5 5-5"/><path d="m7 9 5-5 5 5"/></svg>
     {% else %}
@@ -132,13 +110,12 @@
       id="{{ id }}-listbox"
       aria-orientation="vertical"
       aria-labelledby="{{ id }}-trigger"
-      {% if multiple %}aria-multiselectable="true"{% endif %}
       {% for key, value in listbox_attrs.items() %}
         {{ key }}="{{ value }}"
       {% endfor %}
     >
       {% if items %}
-        {{ render_select_items(items, selectedArray, id ~ "-items" if id else "items") }}
+        {{ render_select_items(items, default_option.value, id ~ "-items" if id else "items") }}
       {% else %}
         {{ caller() if caller }}
       {% endif %}
@@ -147,7 +124,7 @@
   <input
     type="hidden"
     name="{{ name or id ~ '-value' }}"
-    value="{% if multiple %}{{ selectedArray | tojson }}{% else %}{{ (default_option.value if default_option) or '' }}{% endif %}"
+    value="{{ (default_option.value if default_option) or '' }}"
     {% for key, value in input_attrs.items() %}
       {% if key != 'name' and key != 'value' %}{{ key }}="{{ value }}"{% endif %}
     {% endfor %}
@@ -161,7 +138,7 @@
   @param items {array} - The array of items to render.
   @param parent_id_prefix {string} [optional] - The prefix for the item id.
 #}
-{% macro render_select_items(items, selectedArray, parent_id_prefix="items") %}
+{% macro render_select_items(items, selected, parent_id_prefix="items") %}
   {% for item in items %}
     {% set item_id = parent_id_prefix ~ "-" ~ loop.index %}
     {% if item.type == "group" %}
@@ -176,7 +153,7 @@
         {% endif %}
       >
         <div role="heading" id="{{ group_label_id }}">{{ item.label }}</div>
-        {{ render_select_items(item['items'], selectedArray, item_id) if item['items'] }}
+        {{ render_select_items(item.items, selected, item_id) if item.items }}
       </div>
     {% elif item.type == "separator" %}
       <hr role="separator" />
@@ -184,8 +161,8 @@
       <div
         id="{{ item_id }}"
         role="option"
-        {% if item.value is defined and item.value is not none %}data-value="{{ item.value }}"{% endif %}
-        {% if item.value in selectedArray %}aria-selected="true"{% endif %}
+        data-value="{{ item.value }}"
+        {% if selected == item.value %}aria-selected="true"{% endif %}
         {% if item.attrs %}
           {% for key, value in item.attrs.items() %}
             {{ key }}="{{ value }}"

--- a/src/js/select.js
+++ b/src/js/select.js
@@ -3,38 +3,35 @@
     const trigger = selectComponent.querySelector(':scope > button');
     const selectedLabel = trigger.querySelector(':scope > span');
     const popover = selectComponent.querySelector(':scope > [data-popover]');
-    const listbox = popover ? popover.querySelector('[role="listbox"]') : null;
+    const listbox = popover.querySelector('[role="listbox"]');
     const input = selectComponent.querySelector(':scope > input[type="hidden"]');
     const filter = selectComponent.querySelector('header input[type="text"]');
-
     if (!trigger || !popover || !listbox || !input) {
       const missing = [];
       if (!trigger) missing.push('trigger');
       if (!popover) missing.push('popover');
       if (!listbox) missing.push('listbox');
-      if (!input) missing.push('input');
+      if (!input)   missing.push('input');
       console.error(`Select component initialisation failed. Missing element(s): ${missing.join(', ')}`, selectComponent);
       return;
     }
+    
+    const isMultiSelect = listbox.getAttribute('aria-multiselectable') === 'true';
+    const initialSelectedLabel = selectedLabel.cloneNode(true);
+    const allowedMultiSelectBadgeVariants = ['secondary', 'destructive', 'ghost', 'outline'];
 
     const allOptions = Array.from(listbox.querySelectorAll('[role="option"]'));
     const options = allOptions.filter(opt => opt.getAttribute('aria-disabled') !== 'true');
     let visibleOptions = [...options];
     let activeIndex = -1;
-    const isMultiple = listbox.getAttribute('aria-multiselectable') === 'true';
-    const selectedOptions = isMultiple ? new Set() : null;
-    const placeholder = isMultiple ? (selectComponent.dataset.placeholder || '') : null;
-    const closeOnSelect = selectComponent.dataset.closeOnSelect === 'true';
-
-    const getValue = (opt) => opt.dataset.value ?? opt.textContent.trim();
 
     const setActiveOption = (index) => {
       if (activeIndex > -1 && options[activeIndex]) {
         options[activeIndex].classList.remove('active');
       }
-
+      
       activeIndex = index;
-
+      
       if (activeIndex > -1) {
         const activeOption = options[activeIndex];
         activeOption.classList.add('active');
@@ -53,173 +50,233 @@
       return parseFloat(style.transitionDuration) > 0 || parseFloat(style.transitionDelay) > 0;
     };
 
-    const updateValue = (optionOrOptions, triggerEvent = true) => {
-      let value;
-
-      if (isMultiple) {
-        const opts = Array.isArray(optionOrOptions) ? optionOrOptions : [];
-        selectedOptions.clear();
-        opts.forEach(opt => selectedOptions.add(opt));
-
-        // Get selected options in DOM order
-        const selected = options.filter(opt => selectedOptions.has(opt));
-        if (selected.length === 0) {
-          selectedLabel.textContent = placeholder;
-          selectedLabel.classList.add('text-muted-foreground');
+    const updateValue = (option, triggerEvent = true) => {
+      if (option) {
+        if (isMultiSelect) {
+          updateValueMultiSelect(option, triggerEvent);
         } else {
-          selectedLabel.textContent = selected.map(opt => opt.dataset.label || opt.textContent.trim()).join(', ');
-          selectedLabel.classList.remove('text-muted-foreground');
-        }
+          selectedLabel.innerHTML = option.dataset.label || option.innerHTML;
+          input.value = option.dataset.value;
+          listbox.querySelector('[role="option"][aria-selected="true"]')?.removeAttribute('aria-selected');
+          option.setAttribute('aria-selected', 'true');
+          
+          if (triggerEvent) {
+            const event = new CustomEvent('change', {
+              detail: { value: option.dataset.value },
+              bubbles: true
+            });
+            selectComponent.dispatchEvent(event);
+          }
+        }   
+      }
+    };
 
-        value = selected.map(getValue);
-        input.value = JSON.stringify(value);
-      } else {
-        const option = optionOrOptions;
-        if (!option) return;
-        selectedLabel.innerHTML = option.innerHTML;
-        value = getValue(option);
-        input.value = value;
+    const updateValueMultiSelect = (option, triggerEvent = true) => {
+      const selectedOption = option.getAttribute('aria-selected');
+      if (selectedOption === 'true') {
+        option.setAttribute('aria-selected', 'false');
+      } else if (selectedOption === 'false') {
+        option.setAttribute('aria-selected', 'true');
       }
 
-      options.forEach(opt => {
-        const isSelected = isMultiple ? selectedOptions.has(opt) : opt === optionOrOptions;
-        if (isSelected) {
-          opt.setAttribute('aria-selected', 'true');
+      const selected = listbox.querySelectorAll('[role="option"][aria-selected="true"]');
+      const threshold = listbox.dataset.multiselectThreshold || selected.length
+
+      if (selected.length > threshold) {
+
+        const thresholdText = document.createElement('p');
+        thresholdText.textContent = `${selected.length} ` + (listbox.dataset.multiselectThresholdText || 'entries selected')
+
+        if (listbox.getAttribute('aria-controls') !== null) {
+          const controlledElementId = listbox.getAttribute('aria-controls');
+          const controlledElement = document.getElementById(controlledElementId);
+          if (controlledElement !== null) {
+            controlledElement.replaceChildren(thresholdText);
+          } else {
+            console.error(`aria-controls of listbox references an element that does not exist: ${controlledElementId}`, selectComponent);
+            return;
+          }
         } else {
-          opt.removeAttribute('aria-selected');
+          selectedLabel.replaceChildren(thresholdText);
         }
-      });
+      } else if (selected.length > 0) {
+        const badgeContainer = document.createElement('div');
+        badgeContainer.className = 'items-center gap-1 flex';
+
+        selected.forEach(opt => {
+          if (opt.dataset.multiselectDisplay !== undefined) {
+            let display = document.getElementById(opt.dataset.multiselectDisplay);
+            if (display === null) {
+              console.error(`data-multiselect-display of option references an element that does not exist: ${opt}`, selectComponent);
+              return;
+            }
+            display = display.cloneNode(true)
+            display.removeAttribute('hidden')
+            display.removeAttribute('id')
+
+            badgeContainer.appendChild(display);
+          } else {
+            const span = document.createElement('span');
+            const variant = opt.dataset.multiselectVariant;
+            if (variant !== undefined && allowedMultiSelectBadgeVariants.includes(variant)) {
+              span.className = `badge-${variant}`;
+            } else {
+              span.className = 'badge';
+            }
+            span.className += ' font-normal';
+            span.textContent = opt.dataset.label || opt.innerHTML;
+
+            const removeButton = document.createElement('button');
+            removeButton.className = 'btn-ghost w-4 h-4 -m-1';
+            removeButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"></path> <path d="m6 6 12 12"></path></svg>`;
+            removeButton.addEventListener('click', () => {
+              updateValue(opt);
+            });
+            
+            span.insertBefore(removeButton, span.firstChild);
+            badgeContainer.appendChild(span);
+          }
+        });
+
+        if (listbox.getAttribute('aria-controls') !== null) {
+          const controlledElementId = listbox.getAttribute('aria-controls');
+          const controlledElement = document.getElementById(controlledElementId);
+          if (controlledElement !== null) {
+            controlledElement.replaceChildren(...badgeContainer.childNodes);
+          } else {
+            console.error(`aria-controls of listbox references an element that does not exist: ${controlledElementId}`, selectComponent);
+            return;
+          }
+        } else {
+          selectedLabel.replaceChildren(badgeContainer);
+        }
+
+        const clearButton = listbox.querySelector('[data-multiselect-clearelement]');
+
+        if (clearButton === null) {
+          const listboxSeparator = document.createElement('hr');
+          listboxSeparator.setAttribute('data-multiselect-clearelement', "");
+          listboxSeparator.role = 'separator';
+
+          const clearSelectionOption = document.createElement('button');
+          clearSelectionOption.setAttribute('data-multiselect-clearelement', "");
+          clearSelectionOption.className = 'btn-ghost w-full justify-center';
+          clearSelectionOption.textContent = listbox.dataset.multiselectClosetext || 'Clear';
+          clearSelectionOption.addEventListener('click', () => {
+            const selected = listbox.querySelectorAll('[role="option"][aria-selected="true"]');
+            selected.forEach(opt => {
+              opt.setAttribute('aria-selected', 'false');
+            });
+            updateValue(clearSelectionOption);
+          });
+          listbox.append(listboxSeparator, clearSelectionOption)
+        } 
+      } else if (selected.length === 0) {
+        if (listbox.getAttribute('aria-controls') !== null) {
+          const controlledElementId = listbox.getAttribute('aria-controls');
+          const controlledElement = document.getElementById(controlledElementId);
+          if (controlledElement !== null) {
+            controlledElement.replaceChildren();
+          } else {
+            console.error(`aria-controls of listbox references an element that does not exist: ${controlledElementId}`, selectComponent);
+            return;
+          }
+        } else {
+          let initial = initialSelectedLabel.cloneNode(true);
+          selectedLabel.replaceChildren(...initial.childNodes);
+        }
+
+        const clearButtonElements = listbox.querySelectorAll('[data-multiselect-clearelement]');
+        clearButtonElements.forEach(el => {
+            listbox.removeChild(el);
+          });
+      }
+
+      const inputValue = JSON.stringify(Array.from(selected).map(opt => opt.dataset.value))
+
+      input.value = inputValue
 
       if (triggerEvent) {
-        selectComponent.dispatchEvent(new CustomEvent('change', {
-          detail: { value },
+        const event = new CustomEvent('change', {
+          detail: { value: inputValue },
           bubbles: true
-        }));
+        });
+        selectComponent.dispatchEvent(event);
       }
     };
 
     const closePopover = (focusOnTrigger = true) => {
       if (popover.getAttribute('aria-hidden') === 'true') return;
-
+      
       if (filter) {
         const resetFilter = () => {
           filter.value = '';
           visibleOptions = [...options];
           allOptions.forEach(opt => opt.setAttribute('aria-hidden', 'false'));
         };
-
+        
         if (hasTransition()) {
           popover.addEventListener('transitionend', resetFilter, { once: true });
         } else {
           resetFilter();
         }
       }
-
+      
       if (focusOnTrigger) trigger.focus();
       popover.setAttribute('aria-hidden', 'true');
       trigger.setAttribute('aria-expanded', 'false');
       setActiveOption(-1);
-    };
+    }
 
-    const toggleMultipleValue = (option) => {
-      if (selectedOptions.has(option)) {
-        selectedOptions.delete(option);
-      } else {
-        selectedOptions.add(option);
+    const selectOption = (option) => {
+      if (!option) return;
+      
+      const oldValue = input.value;
+      const newValue = option.dataset.value;
+
+      if (newValue != null && newValue !== oldValue) {
+        updateValue(option);
       }
-      updateValue(options.filter(opt => selectedOptions.has(opt)));
-    };
-
-    const select = (value) => {
-      if (isMultiple) {
-        const option = options.find(opt => getValue(opt) === value && !selectedOptions.has(opt));
-        if (!option) return;
-        selectedOptions.add(option);
-        updateValue(options.filter(opt => selectedOptions.has(opt)));
-      } else {
-        const option = options.find(opt => getValue(opt) === value);
-        if (!option) return;
-        if (input.value !== value) {
-          updateValue(option);
-        }
+      
+      if (!isMultiSelect)
+      {
         closePopover();
       }
     };
 
-    const deselect = (value) => {
-      if (!isMultiple) return;
-      const option = options.find(opt => getValue(opt) === value && selectedOptions.has(opt));
-      if (!option) return;
-      selectedOptions.delete(option);
-      updateValue(options.filter(opt => selectedOptions.has(opt)));
-    };
-
-    const toggle = (value) => {
-      if (!isMultiple) return;
-      const option = options.find(opt => getValue(opt) === value);
-      if (!option) return;
-      toggleMultipleValue(option);
+    const selectByValue = (value) => {
+      const option = options.find(opt => opt.dataset.value === value);
+      selectOption(option);
     };
 
     if (filter) {
       const filterOptions = () => {
         const searchTerm = filter.value.trim().toLowerCase();
-
+        
         setActiveOption(-1);
 
         visibleOptions = [];
         allOptions.forEach(option => {
-          if (option.hasAttribute('data-force')) {
-            option.setAttribute('aria-hidden', 'false');
-            if (options.includes(option)) {
-              visibleOptions.push(option);
-            }
-            return;
-          }
-
-          const optionText = (option.dataset.filter || option.textContent).trim().toLowerCase();
-          const keywordList = (option.dataset.keywords || '')
-            .toLowerCase()
-            .split(/[\s,]+/)
-            .filter(Boolean);
-          const matchesKeyword = keywordList.some(keyword => keyword.includes(searchTerm));
-          const matches = optionText.includes(searchTerm) || matchesKeyword;
+          const optionText = (option.dataset.label || option.textContent).trim().toLowerCase();
+          const matches = optionText.includes(searchTerm);
           option.setAttribute('aria-hidden', String(!matches));
           if (matches && options.includes(option)) {
             visibleOptions.push(option);
           }
         });
       };
-
+  
       filter.addEventListener('input', filterOptions);
     }
 
-    // Initialization
-    if (isMultiple) {
-      const ariaSelected = options.filter(opt => opt.getAttribute('aria-selected') === 'true');
-      try {
-        const parsed = JSON.parse(input.value || '[]');
-        const validValues = new Set(options.map(getValue));
-        const initialValues = Array.isArray(parsed) ? parsed.filter(v => validValues.has(v)) : [];
+    let initialOption = options.find(opt => opt.dataset.value === input.value);
+    
+    if (!initialOption) {
+      initialOption = options.find(opt => opt.dataset.value !== undefined) ?? options[0];
+    }
 
-        const initialOptions = [];
-        if (initialValues.length > 0) {
-          // Match values to options in order, allowing duplicates
-          initialValues.forEach(val => {
-            const opt = options.find(o => getValue(o) === val && !initialOptions.includes(o));
-            if (opt) initialOptions.push(opt);
-          });
-        } else {
-          initialOptions.push(...ariaSelected);
-        }
-
-        updateValue(initialOptions, false);
-      } catch (e) {
-        updateValue(ariaSelected, false);
-      }
-    } else {
-      const initialOption = options.find(opt => getValue(opt) === input.value) || options[0];
-      if (initialOption) updateValue(initialOption, false);
+    if (!isMultiSelect) {
+        updateValue(initialOption, false);
     }
 
     const handleKeyNavigation = (event) => {
@@ -236,28 +293,17 @@
         }
         return;
       }
-
+      
       event.preventDefault();
 
       if (event.key === 'Escape') {
         closePopover();
         return;
       }
-
+      
       if (event.key === 'Enter') {
         if (activeIndex > -1) {
-          const option = options[activeIndex];
-          if (isMultiple) {
-            toggleMultipleValue(option);
-            if (closeOnSelect) {
-              closePopover();
-            }
-          } else {
-            if (input.value !== getValue(option)) {
-              updateValue(option);
-            }
-            closePopover();
-          }
+          selectOption(options[activeIndex]);
         }
         return;
       }
@@ -323,7 +369,7 @@
       document.dispatchEvent(new CustomEvent('basecoat:popover', {
         detail: { source: selectComponent }
       }));
-
+      
       if (filter) {
         if (hasTransition()) {
           popover.addEventListener('transitionend', () => {
@@ -336,7 +382,7 @@
 
       popover.setAttribute('aria-hidden', 'false');
       trigger.setAttribute('aria-expanded', 'true');
-
+      
       const selectedOption = listbox.querySelector('[role="option"][aria-selected="true"]');
       if (selectedOption) {
         setActiveOption(options.indexOf(selectedOption));
@@ -355,28 +401,8 @@
 
     listbox.addEventListener('click', (event) => {
       const clickedOption = event.target.closest('[role="option"]');
-      if (!clickedOption) return;
-
-      const option = options.find(opt => opt === clickedOption);
-      if (!option) return;
-
-      if (isMultiple) {
-        toggleMultipleValue(option);
-        if (closeOnSelect) {
-          closePopover();
-        } else {
-          setActiveOption(options.indexOf(option));
-          if (filter) {
-            filter.focus();
-          } else {
-            trigger.focus();
-          }
-        }
-      } else {
-        if (input.value !== getValue(option)) {
-          updateValue(option);
-        }
-        closePopover();
+      if (clickedOption) {
+        selectOption(clickedOption);
       }
     });
 
@@ -393,43 +419,8 @@
     });
 
     popover.setAttribute('aria-hidden', 'true');
-
-    // Public API
-    Object.defineProperty(selectComponent, 'value', {
-      get: () => {
-        if (isMultiple) {
-          return options.filter(opt => selectedOptions.has(opt)).map(getValue);
-        } else {
-          return input.value;
-        }
-      },
-      set: (val) => {
-        if (isMultiple) {
-          const values = Array.isArray(val) ? val : (val != null ? [val] : []);
-          const opts = [];
-          values.forEach(v => {
-            const opt = options.find(o => getValue(o) === v && !opts.includes(o));
-            if (opt) opts.push(opt);
-          });
-          updateValue(opts);
-        } else {
-          const option = options.find(opt => getValue(opt) === val);
-          if (option) {
-            updateValue(option);
-            closePopover();
-          }
-        }
-      }
-    });
-
-    selectComponent.select = select;
-    selectComponent.selectByValue = select; // Backward compatibility alias
-    if (isMultiple) {
-      selectComponent.deselect = deselect;
-      selectComponent.toggle = toggle;
-      selectComponent.selectAll = () => updateValue(options);
-      selectComponent.selectNone = () => updateValue([]);
-    }
+    
+    selectComponent.selectByValue = selectByValue;
     selectComponent.dataset.selectInitialized = true;
     selectComponent.dispatchEvent(new CustomEvent('basecoat:initialized'));
   };

--- a/src/nunjucks/select.njk
+++ b/src/nunjucks/select.njk
@@ -2,11 +2,8 @@
   Renders a select or combobox component.
 
   @param id {string} [optional] - Unique identifier for the select component.
-  @param selected {string|array} [optional] - The initially selected value(s).
+  @param selected {string} [optional] - The initially selected value.
   @param name {string} [optional] - The name attribute for the hidden input storing the selected value.
-  @param multiple {boolean} [optional] [default=false] - Enables multiple selection mode.
-  @param placeholder {string} [optional] - Placeholder text shown when no options are selected (multiple mode only).
-  @param close_on_select {boolean} [optional] [default=false] - Closes the popover when selecting an option in multiple mode.
   @param main_attrs {object} [optional] - Additional HTML attributes for the main container div.
   @param trigger_attrs {object} [optional] - Additional HTML attributes for the trigger button.
   @param popover_attrs {object} [optional] - Additional HTML attributes for the popover content div.
@@ -20,9 +17,6 @@
   selected=None,
   name=None,
   items=None,
-  multiple=false,
-  placeholder=None,
-  close_on_select=false,
   main_attrs={},
   trigger_attrs={},
   popover_attrs={},
@@ -33,15 +27,8 @@
 ) %}
 {% set id = id or ("select-" + (range(100000, 999999) | random | string)) %}
 
-{% if selected is defined and selected is iterable and selected is not string %}
-  {% set selectedArray = selected %}
-{% elif selected is defined %}
-  {% set selectedArray = [selected] %}
-{% else %}
-  {% set selectedArray = [] %}
-{% endif %}
 {% set first_option = [] %}
-{% set selected_options = [] %}
+{% set selected_option = [] %}
 
 {% if items %}
   {% for item in items %}
@@ -50,42 +37,33 @@
         {% if not first_option[0] %}
           {% set first_option = (first_option.push(sub_item), first_option) %}
         {% endif %}
-        {% if sub_item.value in selectedArray %}
-          {% set selected_options = (selected_options.push(sub_item), selected_options) %}
+        {% if selected and sub_item.value == selected and not selected_option[0] %}
+          {% set selected_option = (selected_option.push(sub_item), selected_option) %}
         {% endif %}
       {% endfor %}
     {% else %}
       {% if not first_option[0] %}
         {% set first_option = (first_option.push(item), first_option) %}
       {% endif %}
-      {% if item.value in selectedArray %}
-        {% set selected_options = (selected_options.push(item), selected_options) %}
+      {% if selected and item.value == selected and not selected_option[0] %}
+        {% set selected_option = (selected_option.push(item), selected_option) %}
       {% endif %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
-{% set default_option = (selected_options[0] if selected_options[0] else (first_option[0] if first_option[0] else None)) %}
-{% set labels = [] %}
-{% if multiple and selected_options %}
-  {% for opt in selected_options %}
-    {% set labels = (labels.push(opt.label), labels) %}
-  {% endfor %}
-{% endif %}
-{% set default_label = (labels | join(', ') if (multiple and selected_options) else ((placeholder or '') if (multiple and not selected_options) else (default_option.label if default_option else ''))) %}
+{% set default_option = selected_option[0] or first_option[0] or None %}
 
 <div
   id="{{ id }}"
   class="select {{ main_attrs.class }}"
-  {% if multiple and placeholder %}data-placeholder="{{ placeholder }}"{% endif %}
-  {% if multiple and close_on_select %}data-close-on-select="true"{% endif %}
   {% for key, value in main_attrs %}
     {% if key != 'class' %}{{ key }}="{{ value }}"{% endif %}
   {% endfor %}
 >
   <button
     type="button"
-    class="btn-outline {{ trigger_attrs.class }}"
+    class="btn-outline justify-between font-normal {{ trigger_attrs.class }}"
     id="{{ id }}-trigger"
     aria-haspopup="listbox"
     aria-expanded="false"
@@ -94,7 +72,7 @@
       {% if key != 'class' %}{{ key }}="{{ value }}"{% endif %}
     {% endfor %}
   >
-    <span class="truncate">{{ default_label }}</span>
+    <span class="truncate">{{ default_option.label }}</span>
     {% if is_combobox %}
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevrons-up-down-icon lucide-chevrons-up-down text-muted-foreground opacity-50 shrink-0"><path d="m7 15 5 5 5-5"/><path d="m7 9 5-5 5 5"/></svg>
     {% else %}
@@ -132,13 +110,12 @@
       id="{{ id }}-listbox"
       aria-orientation="vertical"
       aria-labelledby="{{ id }}-trigger"
-      {% if multiple %}aria-multiselectable="true"{% endif %}
       {% for key, value in listbox_attrs %}
         {{ key }}="{{ value }}"
       {% endfor %}
     >
       {% if items and items.length > 0 %}
-        {{ render_select_items(items, selectedArray, id ~ "-items" if id else "items") }}
+        {{ render_select_items(items, default_option.value, id ~ "-items" if id else "items") }}
       {% else %}
         {{ caller() if caller }}
       {% endif %}
@@ -147,7 +124,7 @@
   <input
     type="hidden"
     name="{{ name or id ~ '-value' }}"
-    value="{% if multiple %}{{ selectedArray | dump }}{% else %}{{ (default_option.value if default_option) or '' }}{% endif %}"
+    value="{{ (default_option.value if default_option) or '' }}"
     {% for key, value in input_attrs %}
       {% if key != 'name' and key != 'value' %}{{ key }}="{{ value }}"{% endif %}
     {% endfor %}
@@ -161,7 +138,7 @@
   @param items {array} - The array of items to render.
   @param parent_id_prefix {string} [optional] - The prefix for the item id.
 #}
-{% macro render_select_items(items, selectedArray, parent_id_prefix="items") %}
+{% macro render_select_items(items, selected, parent_id_prefix="items") %}
   {% for item in items %}
     {% set item_id = parent_id_prefix ~ "-" ~ loop.index %}
     {% if item.type == "group" %}
@@ -176,7 +153,7 @@
         {% endif %}
       >
         <div role="heading" id="{{ group_label_id }}">{{ item.label }}</div>
-        {{ render_select_items(item.items, selectedArray, item_id) if item.items }}
+        {{ render_select_items(item.items, selected, item_id) if item.items }}
       </div>
     {% elif item.type == "separator" %}
       <hr role="separator" />
@@ -184,8 +161,8 @@
       <div
         id="{{ item_id }}"
         role="option"
-        {% if item.value is defined and item.value is not none %}data-value="{{ item.value }}"{% endif %}
-        {% if item.value in selectedArray %}aria-selected="true"{% endif %}
+        data-value="{{ item.value }}"
+        {% if selected == item.value %}aria-selected="true"{% endif %}
         {% if item.attrs %}
           {% for key, value in item.attrs %}
             {{ key }}="{{ value }}"


### PR DESCRIPTION
Adds multi-select capability to the existing select component via `aria-multiselectable` attribute on the listbox.

**Usage:**
```html
<select class="select" data-select-initialized>
  <button type="button" aria-expanded="false" aria-haspopup="listbox">
    <span>Select options</span>
    <svg><!-- chevron --></svg>
  </button>
  <input type="hidden" name="values" />
  <div data-popover>
    <header><!-- optional filter --></header>
    <ul role="listbox" aria-multiselectable="true" data-multiselect-threshold="3" data-multiselect-threshold-text="items selected">
      <li role="option" data-value="a">Option A</li>
      <li role="option" data-value="b">Option B</li>
      ...
    </ul>
  </div>
</select>
```

**Features:**
- `aria-multiselectable='true'` on listbox enables multi-select mode
- Click to toggle selection; selected options show checkmark
- When selected count exceeds `data-multiselect-threshold`, shows count badge instead of individual labels
- `data-multiselect-threshold-text` for custom count label (default: 'entries selected')
- `data-multiselect-display` on option references a hidden element for custom badge rendering
- Updates hidden input value with comma-separated selected values

Closes #99