### PR TITLE
fix(tabs): add overflow:visible and z-index to prevent sidebar overflow clipping

### DIFF
--- a/src/css/basecoat.css
+++ b/src/css/basecoat.css
@@ -1169,9 +1169,10 @@
 @layer components {
   .tabs {
     @apply flex flex-col gap-2;
+    overflow: visible;
     
     [role='tablist'] {
-      @apply bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px];
+      @apply relative z-10 flex bg-muted text-muted-foreground h-9 w-fit items-center justify-center rounded-lg p-[3px];
 
       [role='tab'] {
         @apply focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground dark:text-muted-foreground inline-flex h-[calc(100%_-_1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4;


### PR DESCRIPTION
Tabs inside a sidebar nav were being clipped by the sidebar's overflow handling. The tablist would visually overflow its container but the panel dropdowns would be clipped by the sidebar's `overflow:hidden` on the nav element.

**Fix:**
- Add `overflow: visible` to `.tabs` to prevent clipping
- Add `relative z-10` to `[role='tablist']` to ensure tablist renders above sidebar content
- Remove unnecessary `inline-flex` from tablist (flex is inherited from parent)

This fixes both #144 (Tabs inside Sidebar not rendering) and #88 (Tabs display issue on large screens).

Closes #144
Closes #88