### PR TITLE
feat: add Navigation Menu component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Added a new Navigation Menu component with semantic `<nav>`/`<details>` markup, docs, and server-rendered template macros.
+
 ## [1.0.1] - 2026-06-28
 
 ### Added

--- a/scripts/generate-css-entrypoints.js
+++ b/scripts/generate-css-entrypoints.js
@@ -29,6 +29,7 @@ const componentOrder = [
   'kbd',
   'label',
   'native-select',
+  'navigation-menu',
   'popover',
   'progress',
   'radio',

--- a/site/src/docs/components/navigation-menu.mdx
+++ b/site/src/docs/components/navigation-menu.mdx
@@ -1,0 +1,186 @@
+# Navigation Menu
+
+<Preview>
+<nav class="navigation-menu" aria-label="Primary navigation">
+  <ul class="navigation-menu-list">
+    <li class="navigation-menu-item">
+      <a class="navigation-menu-link" href="#getting-started">Getting started</a>
+    </li>
+    <li class="navigation-menu-item">
+      <details open>
+        <summary class="navigation-menu-trigger">Components</summary>
+        <div class="navigation-menu-content">
+          <p data-description>Semantic HTML first, with native disclosure for dropdown content.</p>
+          <ul>
+            <li class="navigation-menu-item">
+              <a class="navigation-menu-link" href="#button">
+                <span>Button</span>
+                <span data-description>Flexible button styles and sizes</span>
+              </a>
+            </li>
+            <li class="navigation-menu-item">
+              <a class="navigation-menu-link" href="#dropdown-menu">
+                <span>Dropdown Menu</span>
+                <span data-description>Menu actions and checked items</span>
+              </a>
+            </li>
+            <li class="navigation-menu-item">
+              <a class="navigation-menu-link" href="#sidebar">
+                <span>Sidebar</span>
+                <span data-description>Vertical navigation with nested sections</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </details>
+    </li>
+    <li class="navigation-menu-item">
+      <a class="navigation-menu-link" href="#docs" aria-current="page">Docs</a>
+    </li>
+  </ul>
+</nav>
+</Preview>
+
+## Usage
+
+<Callout title="Template macros available" icon="code" action={{ label: "More", href: "/templates#navigation_menu" }}>
+  This component ships a `navigation_menu()` macro for Jinja and Nunjucks.
+</Callout>
+
+Basecoat navigation menus are semantic HTML navigation lists with native `<details>` dropdowns. That keeps the component framework-free and avoids the portal/state-machine layer used by shadcn/ui.
+
+<Steps>
+  <Step title="Include CSS">
+
+Import Tailwind and one full Basecoat style bundle.
+
+```css
+@import "tailwindcss";
+@import "basecoat-css/vega.css";
+```
+
+Or import only the base CSS, Navigation Menu component CSS, and one style pack.
+
+```css
+@import "tailwindcss";
+@import "basecoat-css/base.css";
+@import "basecoat-css/components/navigation-menu.css";
+@import "basecoat-css/styles/vega.css";
+```
+
+Using CDN or bundler imports? See the [Installation page](/installation).
+
+  </Step>
+  <Step title="Add your navigation menu HTML">
+```html
+<nav class="navigation-menu" aria-label="Primary navigation">
+  <ul class="navigation-menu-list">
+    <li class="navigation-menu-item">
+      <a class="navigation-menu-link" href="#">Home</a>
+    </li>
+    <li class="navigation-menu-item">
+      <details>
+        <summary class="navigation-menu-trigger">Components</summary>
+        <div class="navigation-menu-content">
+          <ul>
+            <li class="navigation-menu-item">
+              <a class="navigation-menu-link" href="#">
+                <span>Button</span>
+                <span data-description>Flexible button styles and sizes</span>
+              </a>
+            </li>
+            <li class="navigation-menu-item">
+              <a class="navigation-menu-link" href="#">
+                <span>Dropdown Menu</span>
+                <span data-description>Menu actions and checked items</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </details>
+    </li>
+    <li class="navigation-menu-item">
+      <a class="navigation-menu-link" href="#" aria-current="page">Docs</a>
+    </li>
+  </ul>
+</nav>
+```
+  </Step>
+</Steps>
+
+### HTML structure
+
+Basecoat maps shadcn/ui's `NavigationMenu` composition to regular HTML landmarks and native disclosure elements.
+
+<dl>
+  <dt><code>&lt;nav class="navigation-menu"&gt;</code></dt>
+  <dd>Navigation landmark root. Use <code>aria-label</code> to describe the menu.</dd>
+  <dt><code>&lt;ul class="navigation-menu-list"&gt;</code></dt>
+  <dd>Horizontal list of top-level menu items.</dd>
+  <dt><code>&lt;li class="navigation-menu-item"&gt;</code></dt>
+  <dd>Wraps each top-level item or dropdown.</dd>
+  <dt><code>&lt;a class="navigation-menu-link"&gt;</code></dt>
+  <dd>Top-level or panel link. Use <code>aria-current="page"</code> for the active destination.</dd>
+  <dt><code>&lt;details&gt;</code> / <code>&lt;summary class="navigation-menu-trigger"&gt;</code></dt>
+  <dd>Native dropdown trigger. Keep the panel content directly inside the same <code>&lt;details&gt;</code> element.</dd>
+  <dt><code>&lt;div class="navigation-menu-content"&gt;</code></dt>
+  <dd>Dropdown panel. Put a nested <code>&lt;ul&gt;</code> inside it for structured links.</dd>
+</dl>
+
+<Callout type="warning" title="Differences with shadcn/ui" icon="triangle-alert">
+  Basecoat does not port the Radix portal, indicator, or active-state wiring. Dropdowns use native `<details>` and render inline in the document flow so the markup stays portable across server-rendered stacks.
+</Callout>
+
+## Examples
+
+### Link row
+
+```html
+<nav class="navigation-menu" aria-label="Docs sections">
+  <ul class="navigation-menu-list">
+    <li class="navigation-menu-item"><a class="navigation-menu-link" href="#intro">Intro</a></li>
+    <li class="navigation-menu-item"><a class="navigation-menu-link" href="#install">Install</a></li>
+    <li class="navigation-menu-item"><a class="navigation-menu-link" href="#usage" aria-current="page">Usage</a></li>
+  </ul>
+</nav>
+```
+
+### Dropdown panel
+
+```html
+<nav class="navigation-menu" aria-label="Primary navigation">
+  <ul class="navigation-menu-list">
+    <li class="navigation-menu-item">
+      <details open>
+        <summary class="navigation-menu-trigger">Components</summary>
+        <div class="navigation-menu-content">
+          <ul>
+            <li class="navigation-menu-item"><a class="navigation-menu-link" href="#button"><span>Button</span><span data-description>Sizes, variants, and icon buttons</span></a></li>
+            <li class="navigation-menu-item"><a class="navigation-menu-link" href="#dropdown-menu"><span>Dropdown Menu</span><span data-description>Actions, groups, and separators</span></a></li>
+          </ul>
+        </div>
+      </details>
+    </li>
+  </ul>
+</nav>
+```
+
+### Template macro
+
+```jinja
+{% from "basecoat/navigation-menu.njk" import navigation_menu %}
+{{ navigation_menu(
+  label="Primary navigation",
+  items=[
+    { "label": "Home", "url": "/" },
+    {
+      "label": "Components",
+      "description": "Browse the available component docs.",
+      "items": [
+        { "label": "Button", "url": "/components/button" },
+        { "label": "Dropdown Menu", "url": "/components/dropdown-menu" }
+      ]
+    }
+  ]
+) }}
+```

--- a/site/src/docs/docs.json
+++ b/site/src/docs/docs.json
@@ -88,6 +88,7 @@
         "components/kbd",
         "components/label",
         "components/native-select",
+        "components/navigation-menu",
         "components/pagination",
         "components/popover",
         "components/progress",

--- a/site/src/docs/templates.mdx
+++ b/site/src/docs/templates.mdx
@@ -17,6 +17,7 @@ The templates are versioned with `basecoat-css`, so the generated markup matches
 | [Command](/components/command) | `command_dialog()` | [command.njk](https://github.com/hunvreus/basecoat/blob/main/src/templates/nunjucks/command.njk) | [command.html.jinja](https://github.com/hunvreus/basecoat/blob/main/src/templates/jinja/command.html.jinja) |
 | [Dialog](/components/dialog) | `dialog()` | [dialog.njk](https://github.com/hunvreus/basecoat/blob/main/src/templates/nunjucks/dialog.njk) | [dialog.html.jinja](https://github.com/hunvreus/basecoat/blob/main/src/templates/jinja/dialog.html.jinja) |
 | [Dropdown Menu](/components/dropdown-menu) | `dropdown_menu()` | [dropdown-menu.njk](https://github.com/hunvreus/basecoat/blob/main/src/templates/nunjucks/dropdown-menu.njk) | [dropdown-menu.html.jinja](https://github.com/hunvreus/basecoat/blob/main/src/templates/jinja/dropdown-menu.html.jinja) |
+| [Navigation Menu](/components/navigation-menu) | `navigation_menu()` | [navigation-menu.njk](https://github.com/hunvreus/basecoat/blob/main/src/templates/nunjucks/navigation-menu.njk) | [navigation-menu.html.jinja](https://github.com/hunvreus/basecoat/blob/main/src/templates/jinja/navigation-menu.html.jinja) |
 | [Popover](/components/popover) | `popover()` | [popover.njk](https://github.com/hunvreus/basecoat/blob/main/src/templates/nunjucks/popover.njk) | [popover.html.jinja](https://github.com/hunvreus/basecoat/blob/main/src/templates/jinja/popover.html.jinja) |
 | [Select](/components/select) | `select()` | [select.njk](https://github.com/hunvreus/basecoat/blob/main/src/templates/nunjucks/select.njk) | [select.html.jinja](https://github.com/hunvreus/basecoat/blob/main/src/templates/jinja/select.html.jinja) |
 | [Sidebar](/components/sidebar) | `sidebar()` | [sidebar.njk](https://github.com/hunvreus/basecoat/blob/main/src/templates/nunjucks/sidebar.njk) | [sidebar.html.jinja](https://github.com/hunvreus/basecoat/blob/main/src/templates/jinja/sidebar.html.jinja) |
@@ -156,6 +157,20 @@ Some macro files include internal recursive helpers such as `render_select_items
 | `trigger_attrs` | `object` | `{}` | Extra attributes for the trigger button. |
 | `popover_attrs` | `object` | `{}` | Extra attributes for the popover element. |
 | `menu_attrs` | `object` | `{}` | Extra attributes for the menu element. |
+
+### `navigation_menu()`
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `id` | `string` | generated | Unique navigation menu id. |
+| `label` | `string` | `"Primary navigation"` | Navigation landmark label. |
+| `items` | `array` | `None` / `none` | Optional structured item data. Use caller content when omitted. |
+| `main_attrs` | `object` | `{}` | Extra attributes for the `.navigation-menu` root. |
+| `list_attrs` | `object` | `{}` | Extra attributes for the `.navigation-menu-list` element. |
+| `item_attrs` | `object` | `{}` | Extra attributes for each list item. |
+| `trigger_attrs` | `object` | `{}` | Extra attributes for dropdown triggers. |
+| `content_attrs` | `object` | `{}` | Extra attributes for dropdown content panels. |
+| `link_attrs` | `object` | `{}` | Extra attributes for links. |
 
 ### `popover()`
 

--- a/src/css/basecoat-components.css
+++ b/src/css/basecoat-components.css
@@ -22,6 +22,7 @@
 @import "./components/kbd.css";
 @import "./components/label.css";
 @import "./components/native-select.css";
+@import "./components/navigation-menu.css";
 @import "./components/popover.css";
 @import "./components/progress.css";
 @import "./components/radio.css";

--- a/src/css/components/navigation-menu.css
+++ b/src/css/components/navigation-menu.css
@@ -1,0 +1,60 @@
+/* Navigation Menu */
+@layer components {
+  .navigation-menu {
+    @apply relative flex w-full justify-center;
+  }
+
+  .navigation-menu-list {
+    @apply m-0 flex list-none flex-wrap items-center gap-1 p-0;
+  }
+
+  .navigation-menu-item {
+    @apply relative;
+  }
+
+  .navigation-menu :is(a, summary).navigation-menu-trigger,
+  .navigation-menu-link {
+    @apply inline-flex h-10 items-center justify-center gap-2 rounded-md px-3 text-sm font-medium outline-hidden transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50;
+  }
+
+  .navigation-menu :is(a, summary).navigation-menu-trigger {
+    @apply cursor-pointer select-none;
+  }
+
+  .navigation-menu-trigger::after {
+    @apply ms-1 block size-3.5 bg-current content-[''] transition-transform ease-linear rtl:rotate-180;
+    @apply mask-[image:var(--chevron-down-icon)] mask-size-[1rem] mask-no-repeat mask-center;
+  }
+
+  .navigation-menu-item > details[open] > .navigation-menu-trigger {
+    @apply bg-accent text-accent-foreground;
+  }
+
+  .navigation-menu-item > details > .navigation-menu-content {
+    @apply absolute start-0 top-full z-50 mt-2 hidden min-w-64 rounded-lg border bg-popover p-2 shadow-md;
+  }
+
+  .navigation-menu-item > details[open] > .navigation-menu-content {
+    @apply block;
+  }
+
+  .navigation-menu-content > ul {
+    @apply m-0 grid list-none gap-1 p-0;
+  }
+
+  .navigation-menu-content .navigation-menu-link {
+    @apply h-auto w-full items-start justify-start rounded-md px-3 py-2 text-start;
+  }
+
+  .navigation-menu-content .navigation-menu-link > span {
+    @apply block;
+  }
+
+  .navigation-menu-content [data-description] {
+    @apply block text-xs font-normal text-muted-foreground;
+  }
+
+  .navigation-menu [data-rtl-flip] {
+    @apply rtl:rotate-180;
+  }
+}


### PR DESCRIPTION
Adds the new Navigation Menu component for issue #39.

Includes:
- component CSS
- Jinja/Nunjucks macros
- docs page and docs navigation entry
- CSS entrypoint generation updates
- changelog note

Validation:
- npm ci
- npm run build