### PR TITLE
feat: add resizable panel group with handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Added a native resizable panel group with focusable separator handles, pointer and keyboard resizing, style-pack CSS, JavaScript entrypoints, templates, and docs.
+
 ## [1.0.1] - 2026-06-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "./popover.min": "./dist/js/popover.min.js",
     "./range": "./dist/js/range.js",
     "./range.min": "./dist/js/range.min.js",
+    "./resizable": "./dist/js/resizable.js",
+    "./resizable.min": "./dist/js/resizable.min.js",
     "./select": "./dist/js/select.js",
     "./select.min": "./dist/js/select.min.js",
     "./sidebar": "./dist/js/sidebar.js",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -108,7 +108,7 @@ async function build() {
 
   // Create combined component files
   console.log('Creating combined component files...');
-  const componentsToCombine = ['basecoat.js', 'accordion.js', 'command.js', 'combobox.js', 'drawer.js', 'dropdown-menu.js', 'popover.js', 'range.js', 'select.js', 'sidebar.js', 'tabs.js', 'toast.js'];
+  const componentsToCombine = ['basecoat.js', 'accordion.js', 'command.js', 'combobox.js', 'drawer.js', 'dropdown-menu.js', 'popover.js', 'range.js', 'resizable.js', 'select.js', 'sidebar.js', 'tabs.js', 'toast.js'];
   const componentPaths = componentsToCombine.map(f => path.join(srcJsDir, f));
 
   // Create non-minified bundle

--- a/scripts/generate-css-entrypoints.js
+++ b/scripts/generate-css-entrypoints.js
@@ -33,6 +33,7 @@ const componentOrder = [
   'progress',
   'radio',
   'range',
+  'resizable',
   'select',
   'sidebar',
   'scrollbar',

--- a/site/src/docs/components/resizable.mdx
+++ b/site/src/docs/components/resizable.mdx
@@ -1,0 +1,162 @@
+# Resizable
+
+<Preview class="w-full max-w-3xl">
+<div class="resizable h-64 w-full rounded-lg border" data-orientation="horizontal">
+  <section class="flex min-w-0 flex-col gap-2 border-r p-4">
+    <h3 class="text-sm font-medium">Sidebar</h3>
+    <p class="text-sm text-muted-foreground">Drag the handle to change panel sizes.</p>
+  </section>
+  <div role="separator" tabindex="0" aria-label="Resize sidebar and content panels"></div>
+  <section class="flex min-w-0 flex-col gap-2 p-4">
+    <h3 class="text-sm font-medium">Content</h3>
+    <p class="text-sm text-muted-foreground">Panels use percentage sizes and stay within their min/max limits.</p>
+  </section>
+</div>
+</Preview>
+
+## Usage
+
+<Callout title="Template macros available" icon="code" action={{ label: "More", href: "/templates#resizable" }}>
+  This component ships a `resizable()` macro for Jinja and Nunjucks.
+</Callout>
+
+Resizable uses a root `.resizable` container, direct child panels, and focusable separator handles. Basecoat handles pointer dragging, keyboard resizing, and visible handle styling.
+
+<Steps>
+  <Step title="Include CSS">
+
+Import Tailwind and one full Basecoat style bundle.
+
+```css
+@import "tailwindcss";
+@import "basecoat-css/vega.css";
+```
+
+Or import only the base CSS, Resizable component CSS, and one style pack.
+
+```css
+@import "tailwindcss";
+@import "basecoat-css/base.css";
+@import "basecoat-css/components/resizable.css";
+@import "basecoat-css/styles/vega.css";
+```
+
+Using CDN or bundler imports? See the [Installation page](/installation).
+
+  </Step>
+  <Step title="Include JavaScript">
+
+Copy or serve the full Basecoat JavaScript bundle.
+
+```html
+<script src="/assets/js/all.min.js" defer></script>
+```
+
+Or copy or serve the Basecoat runtime and Resizable script.
+
+```html
+<script src="/assets/js/basecoat.min.js" defer></script>
+<script src="/assets/js/resizable.min.js" defer></script>
+```
+
+Using CDN or bundler imports? See the [Installation page](/installation).
+
+  </Step>
+  <Step title="Add your resizable HTML">
+
+Use a `.resizable` root with direct child panels and one or more focusable `role="separator"` handles between them. Set `data-orientation="vertical"` for a top/bottom split.
+
+```html
+<div class="resizable h-64 w-full rounded-lg border" data-orientation="horizontal">
+  <section class="flex min-w-0 flex-col gap-2 border-r p-4" style="--resizable-size: 30%">
+    <h3 class="text-sm font-medium">Sidebar</h3>
+    <p class="text-sm text-muted-foreground">Drag the handle to change panel sizes.</p>
+  </section>
+  <div role="separator" tabindex="0" aria-label="Resize sidebar and content panels"></div>
+  <section class="flex min-w-0 flex-col gap-2 p-4" style="--resizable-size: 70%">
+    <h3 class="text-sm font-medium">Content</h3>
+    <p class="text-sm text-muted-foreground">Panels use percentage sizes and stay within their min/max limits.</p>
+  </section>
+</div>
+```
+
+  </Step>
+</Steps>
+
+### HTML structure
+
+<dl>
+  <dt><code>&lt;div class="resizable" data-orientation="horizontal|vertical"&gt;</code></dt>
+  <dd>
+    Resizable root. Direct children that are not separators become panels. Each panel can set <code>--resizable-size</code> or <code>data-size</code> to define its initial percentage width or height.
+    <dl>
+      <dt><code>&lt;section&gt;</code> or other direct child panel</dt>
+      <dd>Panel content. Add <code>data-min-size</code> and <code>data-max-size</code> to constrain resizing, both expressed as percentages.</dd>
+      <dt><code>&lt;div role="separator" tabindex="0" aria-orientation="vertical|horizontal"&gt;</code></dt>
+      <dd>Focusable resize handle between panels. Use <code>aria-label</code> to describe the adjacent panes when the handle is not self-explanatory.</dd>
+    </dl>
+  </dd>
+</dl>
+
+Basecoat intentionally maps Resizable to plain HTML panels and separators instead of shadcn/ui's React panel primitives. The behavior is the same idea, but the surface is smaller and easier to use in non-React stacks.
+
+### JavaScript API
+
+| API | Type | Description |
+| --- | --- | --- |
+| `resizable.refresh()` | Method | Re-reads the panel and separator structure after direct children change. |
+
+## Examples
+
+### Vertical
+
+<Preview class="w-full max-w-3xl">
+<div class="resizable h-64 w-full rounded-lg border" data-orientation="vertical">
+  <section class="flex min-h-0 flex-col gap-2 border-b p-4" style="--resizable-size: 35%">
+    <h3 class="text-sm font-medium">Header</h3>
+    <p class="text-sm text-muted-foreground">This split resizes vertically.</p>
+  </section>
+  <div role="separator" tabindex="0" aria-label="Resize header and content panels"></div>
+  <section class="flex min-h-0 flex-col gap-2 p-4" style="--resizable-size: 65%">
+    <h3 class="text-sm font-medium">Content</h3>
+    <p class="text-sm text-muted-foreground">The separator is horizontal in vertical mode.</p>
+  </section>
+</div>
+</Preview>
+
+### Three panels
+
+<Preview class="w-full max-w-3xl">
+<div class="resizable h-64 w-full rounded-lg border" data-orientation="horizontal">
+  <section class="flex min-w-0 flex-col gap-2 border-r p-4" style="--resizable-size: 20%">
+    <h3 class="text-sm font-medium">Nav</h3>
+    <p class="text-sm text-muted-foreground">Panel one.</p>
+  </section>
+  <div role="separator" tabindex="0" aria-label="Resize nav and editor panels"></div>
+  <section class="flex min-w-0 flex-col gap-2 border-r p-4" style="--resizable-size: 40%">
+    <h3 class="text-sm font-medium">Editor</h3>
+    <p class="text-sm text-muted-foreground">Panel two.</p>
+  </section>
+  <div role="separator" tabindex="0" aria-label="Resize editor and preview panels"></div>
+  <section class="flex min-w-0 flex-col gap-2 p-4" style="--resizable-size: 40%">
+    <h3 class="text-sm font-medium">Preview</h3>
+    <p class="text-sm text-muted-foreground">Panel three.</p>
+  </section>
+</div>
+</Preview>
+
+### RTL
+
+<Preview class="w-full max-w-3xl" dir="rtl">
+<div class="resizable h-64 w-full rounded-lg border" data-orientation="horizontal">
+  <section class="flex min-w-0 flex-col gap-2 border-r p-4" style="--resizable-size: 30%">
+    <h3 class="text-sm font-medium">واحد</h3>
+    <p class="text-sm text-muted-foreground">Drag the handle in RTL mode too.</p>
+  </section>
+  <div role="separator" tabindex="0" aria-label="Resize panels"></div>
+  <section class="flex min-w-0 flex-col gap-2 p-4" style="--resizable-size: 70%">
+    <h3 class="text-sm font-medium">اثنان</h3>
+    <p class="text-sm text-muted-foreground">Arrow keys follow the document direction.</p>
+  </section>
+</div>
+</Preview>

--- a/site/src/docs/docs.json
+++ b/site/src/docs/docs.json
@@ -92,6 +92,7 @@
         "components/popover",
         "components/progress",
         "components/radio-group",
+        "components/resizable",
         "components/select",
         "components/scroll-area",
         "components/sidebar",

--- a/site/src/docs/templates.mdx
+++ b/site/src/docs/templates.mdx
@@ -167,6 +167,15 @@ Some macro files include internal recursive helpers such as `render_select_items
 | `trigger_attrs` | `object` | `{}` | Extra attributes for the trigger button. |
 | `popover_attrs` | `object` | `{}` | Extra attributes for the popover element. |
 
+### `resizable()`
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `id` | `string` | generated | Unique resizable id. |
+| `panels` | `array` | `[]` | Panel definitions. Each item can include `content`, `panel_attrs`, and `tag`. |
+| `main_attrs` | `object` | `{}` | Extra attributes for the `.resizable` root. |
+| `default_sizes` | `array` | `[]` | Initial panel sizes as percentages. Missing values are distributed evenly. |
+
 ### `select()`
 
 | Prop | Type | Default | Description |

--- a/src/css/basecoat-components.css
+++ b/src/css/basecoat-components.css
@@ -26,6 +26,7 @@
 @import "./components/progress.css";
 @import "./components/radio.css";
 @import "./components/range.css";
+@import "./components/resizable.css";
 @import "./components/select.css";
 @import "./components/sidebar.css";
 @import "./components/scrollbar.css";

--- a/src/css/components/resizable.css
+++ b/src/css/components/resizable.css
@@ -1,0 +1,57 @@
+/* Resizable */
+@layer components {
+  .resizable {
+    @apply flex min-h-0 min-w-0 overflow-hidden;
+
+    &[data-orientation='horizontal'] {
+      @apply flex-row;
+    }
+
+    &[data-orientation='vertical'] {
+      @apply flex-col;
+    }
+
+    > :not([role='separator']) {
+      @apply min-h-0 min-w-0 overflow-auto;
+      flex: 0 0 var(--resizable-size, auto);
+    }
+
+    > [role='separator'] {
+      @apply relative flex-none select-none touch-none outline-none transition-colors duration-150;
+
+      &:focus-visible {
+        @apply ring-2 ring-ring ring-offset-2 ring-offset-background;
+      }
+
+      &:hover::before,
+      &:focus-visible::before,
+      &[data-active='true']::before {
+        @apply bg-foreground/70;
+      }
+
+      &[aria-orientation='vertical'] {
+        @apply h-full w-4 cursor-col-resize;
+
+        &::before {
+          @apply absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border content-[''];
+        }
+
+        &::after {
+          @apply absolute left-1/2 top-1/2 h-8 w-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-border content-[''];
+        }
+      }
+
+      &[aria-orientation='horizontal'] {
+        @apply h-4 w-full cursor-row-resize;
+
+        &::before {
+          @apply absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-border content-[''];
+        }
+
+        &::after {
+          @apply absolute left-1/2 top-1/2 h-1 w-8 -translate-x-1/2 -translate-y-1/2 rounded-full bg-border content-[''];
+        }
+      }
+    }
+  }
+}

--- a/src/js/resizable.js
+++ b/src/js/resizable.js
@@ -1,0 +1,237 @@
+(() => {
+  const DEFAULT_MIN = 10;
+  const DEFAULT_MAX = 90;
+  const DEFAULT_STEP = 5;
+
+  const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+  const parseNumber = (value) => {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  };
+
+  const getPanels = (root) => Array.from(root.children).filter((child) => child.getAttribute('role') !== 'separator');
+
+  const getSeparators = (root) => Array.from(root.children).filter((child) => child.getAttribute('role') === 'separator');
+
+  const readSize = (panel) => parseNumber(panel.dataset.size) ?? parseNumber(panel.style.getPropertyValue('--resizable-size'));
+  const readMin = (panel) => parseNumber(panel.dataset.minSize) ?? DEFAULT_MIN;
+  const readMax = (panel) => parseNumber(panel.dataset.maxSize) ?? DEFAULT_MAX;
+
+  const resolveSizes = (panels, previousSizes = []) => {
+    const sizes = panels.map((panel, index) => readSize(panel) ?? previousSizes[index] ?? null);
+    const knownTotal = sizes.reduce((sum, size) => sum + (Number.isFinite(size) ? size : 0), 0);
+    const missing = sizes.filter((size) => !Number.isFinite(size)).length;
+
+    if (missing === 0) {
+      return normalizeSizes(sizes);
+    }
+
+    const remaining = Math.max(0, 100 - knownTotal);
+    const fallback = missing > 0 ? remaining / missing : 0;
+    return normalizeSizes(sizes.map((size) => (Number.isFinite(size) ? size : fallback)));
+  };
+
+  const normalizeSizes = (sizes) => {
+    const total = sizes.reduce((sum, size) => sum + size, 0) || 1;
+    const rounded = sizes.map((size) => (size / total) * 100);
+    const roundedTotal = rounded.reduce((sum, size) => sum + size, 0);
+    const delta = 100 - roundedTotal;
+    if (rounded.length) rounded[rounded.length - 1] += delta;
+    return rounded;
+  };
+
+  const applySizes = (panels, sizes) => {
+    panels.forEach((panel, index) => {
+      const size = sizes[index] ?? 0;
+      panel.style.setProperty('--resizable-size', `${size}%`);
+    });
+  };
+
+  const collectStructure = (root) => {
+    const panels = [];
+    const handles = [];
+
+    Array.from(root.children).forEach((child) => {
+      if (child.getAttribute('role') === 'separator') {
+        const leftIndex = panels.length - 1;
+        const rightIndex = panels.length;
+        if (leftIndex >= 0) {
+          handles.push({ element: child, leftIndex, rightIndex });
+        }
+        return;
+      }
+
+      panels.push(child);
+    });
+
+    return { panels, handles };
+  };
+
+  const initResizable = (root) => {
+    if (root.dataset.resizableInitialized) return;
+
+    const state = {
+      panels: [],
+      handles: [],
+      sizes: [],
+      activeHandle: null,
+      pointerId: null,
+      dragStart: 0,
+      dragSizes: [],
+      direction: getComputedStyle(root).direction || 'ltr',
+      destroyers: [],
+    };
+
+    const cleanupListeners = () => {
+      while (state.destroyers.length) {
+        const destroy = state.destroyers.pop();
+        destroy();
+      }
+    };
+
+    const updateHandleState = (handle, active) => {
+      handle.dataset.active = active ? 'true' : 'false';
+    };
+
+    const syncSizes = (nextSizes = state.sizes) => {
+      state.sizes = resolveSizes(state.panels, nextSizes);
+      applySizes(state.panels, state.sizes);
+    };
+
+    const resizePair = (leftIndex, rightIndex, delta) => {
+      const leftPanel = state.panels[leftIndex];
+      const rightPanel = state.panels[rightIndex];
+      if (!leftPanel || !rightPanel) return;
+
+      const total = state.dragSizes[leftIndex] + state.dragSizes[rightIndex];
+      const leftMin = Math.max(readMin(leftPanel), total - readMax(rightPanel));
+      const leftMax = Math.min(readMax(leftPanel), total - readMin(rightPanel));
+      const nextLeft = clamp(state.dragSizes[leftIndex] + delta, leftMin, leftMax);
+      const nextRight = total - nextLeft;
+
+      state.sizes[leftIndex] = nextLeft;
+      state.sizes[rightIndex] = nextRight;
+      applySizes(state.panels, state.sizes);
+    };
+
+    const finishDrag = () => {
+      if (!state.activeHandle) return;
+      updateHandleState(state.activeHandle, false);
+      state.activeHandle = null;
+      state.pointerId = null;
+      state.dragStart = 0;
+      state.dragSizes = [];
+      document.body.style.removeProperty('cursor');
+      document.body.style.removeProperty('user-select');
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', finishDrag);
+      window.removeEventListener('pointercancel', finishDrag);
+    };
+
+    const handlePointerMove = (event) => {
+      if (!state.activeHandle || event.pointerId !== state.pointerId) return;
+
+      const rect = root.getBoundingClientRect();
+      const isVertical = root.dataset.orientation === 'vertical';
+      const inlineDirection = state.direction === 'rtl' && !isVertical ? -1 : 1;
+      const movement = isVertical
+        ? ((event.clientY - state.dragStart) / Math.max(rect.height, 1)) * 100
+        : ((event.clientX - state.dragStart) / Math.max(rect.width, 1)) * 100 * inlineDirection;
+      const delta = movement;
+
+      resizePair(state.activeHandle.leftIndex, state.activeHandle.rightIndex, delta);
+    };
+
+    const startDrag = (handleMeta, event) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+
+      state.activeHandle = handleMeta;
+      state.pointerId = event.pointerId;
+      state.dragStart = root.dataset.orientation === 'vertical' ? event.clientY : event.clientX;
+      state.dragSizes = state.sizes.slice();
+      updateHandleState(handleMeta.element, true);
+      document.body.style.cursor = root.dataset.orientation === 'vertical' ? 'row-resize' : 'col-resize';
+      document.body.style.userSelect = 'none';
+
+      window.addEventListener('pointermove', handlePointerMove);
+      window.addEventListener('pointerup', finishDrag);
+      window.addEventListener('pointercancel', finishDrag);
+    };
+
+    const handleKeydown = (handleMeta, event) => {
+      const isVertical = root.dataset.orientation === 'vertical';
+      const key = event.key;
+      const step = event.shiftKey ? 1 : DEFAULT_STEP;
+      const inlineDirection = state.direction === 'rtl' && !isVertical ? -1 : 1;
+      let delta = 0;
+
+      if (!isVertical && key === 'ArrowLeft') delta = -step * inlineDirection;
+      if (!isVertical && key === 'ArrowRight') delta = step * inlineDirection;
+      if (isVertical && key === 'ArrowUp') delta = -step;
+      if (isVertical && key === 'ArrowDown') delta = step;
+      if (!delta) return;
+
+      event.preventDefault();
+      resizePair(handleMeta.leftIndex, handleMeta.rightIndex, delta);
+    };
+
+    const bindHandles = () => {
+      cleanupListeners();
+      state.handles.forEach((handleMeta) => {
+        const { element } = handleMeta;
+        if (!element.hasAttribute('tabindex')) element.tabIndex = 0;
+        if (!element.hasAttribute('aria-orientation')) {
+          element.setAttribute('aria-orientation', root.dataset.orientation === 'vertical' ? 'horizontal' : 'vertical');
+        }
+        if (!element.hasAttribute('aria-label')) element.setAttribute('aria-label', 'Resize panels');
+
+        const onPointerDown = (event) => startDrag(handleMeta, event);
+        const onKeyDown = (event) => handleKeydown(handleMeta, event);
+
+        element.addEventListener('pointerdown', onPointerDown);
+        element.addEventListener('keydown', onKeyDown);
+        state.destroyers.push(() => {
+          element.removeEventListener('pointerdown', onPointerDown);
+          element.removeEventListener('keydown', onKeyDown);
+        });
+      });
+    };
+
+    const refresh = () => {
+      const structure = collectStructure(root);
+      state.panels = structure.panels;
+      state.handles = structure.handles;
+      state.direction = getComputedStyle(root).direction || 'ltr';
+      syncSizes(state.sizes.length === state.panels.length ? state.sizes : []);
+      bindHandles();
+    };
+
+    root.refresh = refresh;
+    root._destroy = () => {
+      finishDrag();
+      cleanupListeners();
+      delete root.refresh;
+      delete root._destroy;
+    };
+
+    state.panels = collectStructure(root).panels;
+    state.handles = collectStructure(root).handles;
+
+    if (state.panels.length < 2 || state.handles.length === 0) {
+      root._destroy();
+      return;
+    }
+
+    root.dataset.orientation = root.dataset.orientation === 'vertical' ? 'vertical' : 'horizontal';
+    syncSizes();
+    bindHandles();
+    root.dataset.resizableInitialized = 'true';
+    root.dispatchEvent(new CustomEvent('basecoat:initialized'));
+  };
+
+  if (window.basecoat) {
+    window.basecoat.register('resizable', '.resizable:not([data-resizable-initialized])', initResizable);
+  }
+})();


### PR DESCRIPTION
Closes #31.\n\nAdds a native resizable panel group with focusable separator handles, pointer and keyboard resizing, CSS, JS, templates, and docs.\n\nValidation:\n- npm run build\n- npm run docs:build