### PR TITLE
Fix iOS auto-zoom on select and command search inputs

### DIFF
--- a/src/css/styles/luma.css
+++ b/src/css/styles/luma.css
@@ -373,7 +373,7 @@
   }
 
   .command > header input {
-    @apply ps-1.5 text-sm placeholder:text-muted-foreground;
+    @apply ps-1.5 text-base md:text-sm placeholder:text-muted-foreground;
   }
 
   .command [role='menu'] {
@@ -415,7 +415,7 @@
 
   /* Combobox */
   .combobox > input[role='combobox'] {
-    @apply bg-input/50 border-transparent focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-9 rounded-3xl border py-2 ps-3 pe-8 text-sm transition-[color,box-shadow,background-color] focus-visible:ring-3 aria-invalid:ring-3;
+    @apply bg-input/50 border-transparent focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-9 rounded-3xl border py-2 ps-3 pe-8 text-base md:text-sm transition-[color,box-shadow,background-color] focus-visible:ring-3 aria-invalid:ring-3;
   }
 
   .combobox > svg,

--- a/src/css/styles/lyra.css
+++ b/src/css/styles/lyra.css
@@ -361,7 +361,7 @@
   }
 
   .command > header input {
-    @apply ps-1.5 text-xs placeholder:text-muted-foreground;
+    @apply ps-1.5 text-base md:text-xs placeholder:text-muted-foreground;
   }
 
   .command [role='menu'] {
@@ -403,7 +403,7 @@
 
   /* Combobox */
   .combobox > input[role='combobox'] {
-    @apply border-input dark:bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-8 rounded-none border bg-transparent py-2 ps-2.5 pe-8 text-xs transition-colors focus-visible:ring-1 aria-invalid:ring-1;
+    @apply border-input dark:bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-8 rounded-none border bg-transparent py-2 ps-2.5 pe-8 text-base md:text-xs transition-colors focus-visible:ring-1 aria-invalid:ring-1;
   }
 
   .combobox > svg,

--- a/src/css/styles/maia.css
+++ b/src/css/styles/maia.css
@@ -365,7 +365,7 @@
   }
 
   .command > header input {
-    @apply ps-1.5 text-sm placeholder:text-muted-foreground;
+    @apply ps-1.5 text-base md:text-sm placeholder:text-muted-foreground;
   }
 
   .command [role='menu'] {
@@ -407,7 +407,7 @@
 
   /* Combobox */
   .combobox > input[role='combobox'] {
-    @apply border-input bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-9 rounded-4xl border py-2 ps-3 pe-8 text-sm transition-colors focus-visible:ring-[3px] aria-invalid:ring-[3px];
+    @apply border-input bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-9 rounded-4xl border py-2 ps-3 pe-8 text-base md:text-sm transition-colors focus-visible:ring-[3px] aria-invalid:ring-[3px];
   }
 
   .combobox > svg,

--- a/src/css/styles/mira.css
+++ b/src/css/styles/mira.css
@@ -365,7 +365,7 @@
   }
 
   .command > header input {
-    @apply ps-1.5 text-xs/relaxed placeholder:text-muted-foreground;
+    @apply ps-1.5 text-base md:text-xs/relaxed placeholder:text-muted-foreground;
   }
 
   .command [role='menu'] {
@@ -407,7 +407,7 @@
 
   /* Combobox */
   .combobox > input[role='combobox'] {
-    @apply border-input bg-input/20 focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-7 rounded-md border py-1 ps-2 pe-6 text-xs/relaxed transition-colors focus-visible:ring-2 aria-invalid:ring-2;
+    @apply border-input bg-input/20 focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-7 rounded-md border py-1 ps-2 pe-6 text-base md:text-xs/relaxed transition-colors focus-visible:ring-2 aria-invalid:ring-2;
   }
 
   .combobox > svg,

--- a/src/css/styles/nova.css
+++ b/src/css/styles/nova.css
@@ -361,7 +361,7 @@
   }
 
   .command > header input {
-    @apply ps-1.5 text-sm placeholder:text-muted-foreground;
+    @apply ps-1.5 text-base md:text-sm placeholder:text-muted-foreground;
   }
 
   .command [role='menu'] {
@@ -403,7 +403,7 @@
 
   /* Combobox */
   .combobox > input[role='combobox'] {
-    @apply border-input dark:bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-8 rounded-lg border bg-transparent py-1 ps-2.5 pe-8 text-sm transition-colors focus-visible:ring-3 aria-invalid:ring-3;
+    @apply border-input dark:bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-8 rounded-lg border bg-transparent py-1 ps-2.5 pe-8 text-base md:text-sm transition-colors focus-visible:ring-3 aria-invalid:ring-3;
   }
 
   .combobox > svg,

--- a/src/css/styles/rhea.css
+++ b/src/css/styles/rhea.css
@@ -373,7 +373,7 @@
   }
 
   .command > header input {
-    @apply ps-1.5 text-sm placeholder:text-muted-foreground;
+    @apply ps-1.5 text-base md:text-sm placeholder:text-muted-foreground;
   }
 
   .command [role='menu'] {
@@ -415,7 +415,7 @@
 
   /* Combobox */
   .combobox > input[role='combobox'] {
-    @apply bg-input/50 border-transparent focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-8 rounded-2xl border py-1 ps-2.5 pe-8 text-sm transition-[color,box-shadow] duration-200 focus-visible:ring-3 aria-invalid:ring-3;
+    @apply bg-input/50 border-transparent focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-8 rounded-2xl border py-1 ps-2.5 pe-8 text-base md:text-sm transition-[color,box-shadow] duration-200 focus-visible:ring-3 aria-invalid:ring-3;
   }
 
   .combobox > svg,

--- a/src/css/styles/sera.css
+++ b/src/css/styles/sera.css
@@ -377,7 +377,7 @@
   }
 
   .command > header input {
-    @apply h-9 ps-1.5 pe-2 text-sm placeholder:text-muted-foreground;
+    @apply h-9 ps-1.5 pe-2 text-base md:text-sm placeholder:text-muted-foreground;
   }
 
   .command [role='menu'] {
@@ -419,7 +419,7 @@
 
   /* Combobox */
   .combobox > input[role='combobox'] {
-    @apply border-transparent border-b-input bg-transparent focus-visible:border-b-ring aria-invalid:border-b-destructive dark:aria-invalid:border-b-destructive/50 h-10 rounded-none border py-2 ps-0 pe-8 text-sm transition-[color,border-color];
+    @apply border-transparent border-b-input bg-transparent focus-visible:border-b-ring aria-invalid:border-b-destructive dark:aria-invalid:border-b-destructive/50 h-10 rounded-none border py-2 ps-0 pe-8 text-base md:text-sm transition-[color,border-color];
   }
 
   .combobox > svg,

--- a/src/css/styles/vega.css
+++ b/src/css/styles/vega.css
@@ -361,7 +361,7 @@
   }
 
   .command > header input {
-    @apply ps-1.5 text-sm placeholder:text-muted-foreground;
+    @apply ps-1.5 text-base md:text-sm placeholder:text-muted-foreground;
   }
 
   .command [role='menu'] {
@@ -403,7 +403,7 @@
 
   /* Combobox */
   .combobox > input[role='combobox'] {
-    @apply border-input dark:bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-9 rounded-md border bg-transparent py-2 ps-2.5 pe-8 text-sm shadow-xs transition-[color,box-shadow] focus-visible:ring-3 aria-invalid:ring-3;
+    @apply border-input dark:bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-9 rounded-md border bg-transparent py-2 ps-2.5 pe-8 text-base md:text-sm shadow-xs transition-[color,box-shadow] focus-visible:ring-3 aria-invalid:ring-3;
   }
 
   .combobox > svg,


### PR DESCRIPTION
The select combobox and command search inputs had _text-sm_ on all screen sizes, which triggers auto-zoom on iOS browsers when tapping. Fixed by using _text-base md:text-sm_, same pattern used on regular inputs.